### PR TITLE
base3.version(): Fix multi-hyphen version string handling

### DIFF
--- a/base3.py
+++ b/base3.py
@@ -613,6 +613,11 @@ def version(v):
     # if we get something like "v0.10.7-2", remove everything except "." and "-",
     # and convert "-" to "."
     v = re.sub(r'[^0-9\.-]', '', v)
+    
+    # For something like "5.13.19-4-pve", remove everything after the last hyphen
+    if v.count('-') > 1:
+        v = v.rsplit('-', 1)[0]
+    
     v = v.replace('-', '.')
     return tuple(map(int, (v.split("."))))
 


### PR DESCRIPTION
This fixes Linuxfabrik/monitoring-plugins#552.

When comparing a version string which contains more than one hyphen (e. g. `5.13.19-4-pve`, provided by Proxmox VE) by using `base3.version()`, this error pops up:
```python
bb@ct-mon1:/tmp$ python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import lib.base3
>>> import platform
>>> platform.release()
'5.13.19-4-pve'
>>> lib.base3.version(platform.release()) >= lib.base3.version('4.18.0')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/lib/base3.py", line 617, in version
    return tuple(map(int, (v.split("."))))
ValueError: invalid literal for int() with base 10: ''
```