### PR TITLE
Fix url for domain mode.

### DIFF
--- a/wildfly3.py
+++ b/wildfly3.py
@@ -22,7 +22,7 @@ from .globals3 import STATE_UNKNOWN
 def get_data(args, data, url=''):
     url = args.URL + '/management' + url
     if args.MODE == 'domain':
-        url = '/host/{}/server/{}'.format(args.NODE, args.INSTANCE) + url
+        url = url + '/host/{}/server/{}'.format(args.NODE, args.INSTANCE)
     header = {'Content-Type': 'application/json'}
     result = base3.coe(url3.fetch_json(
         url, timeout=args.TIMEOUT,


### PR DESCRIPTION
The wildfly-memory-usage check is returning the following error: 
`Unknown error while fetching /host/{my_host}/server/{my_instance}http://localhost:9990/management, maybe timeout or error on webserver`
It seems the URL was concatenated in the wrong order when using domain mode.
