### PR TITLE
Fixed static path to udevadm

### DIFF
--- a/disk.py
+++ b/disk.py
@@ -251,7 +251,7 @@ def udevadm(device, _property):
     >>> udevadm('/dev/linuxfabrik', 'DEVNAME')
     ''
     """
-    success, result = shell.shell_exec('/sbin/udevadm info --query=property --name={}'.format(
+    success, result = shell.shell_exec('udevadm info --query=property --name={}'.format(
         device,
     ))
     if not success:


### PR DESCRIPTION
the udevadm binary is located in vastly different paths depending on the os present. So instead of setting it with a fixed full path, remove the path and let the os search for the binary in $PATH.

Here are some examples where the binary resied under different os versions:
ubuntu_20.04: /bin/udevadm
debian_12: /usr/bin/udevadm
centos_7: /usr/sbin/udevadm