### PR TITLE
fix(url): fall back to Latin-1 when a response has no declared charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * redfish.py: a cached Redfish session token is now kept only as long as the controller itself keeps the session alive, read from the controller's own session timeout. This avoids sporadic "401 Unauthorized" errors on controllers with short session timeouts (such as Supermicro's 300 seconds) without having to tune the cache expiration by hand ([#246](https://github.com/Linuxfabrik/lib/issues/246)).
 * time.py: clarified the `timestr2epoch(..., pattern='iso8601')` docstring - the mode is backed by `datetime.fromisoformat()`, not a full ISO 8601 parser, and which layouts it accepts beyond RFC 3339 depends on the Python version.
 
+### Fixed
+
+* url.py: fetching a page or JSON no longer fails with a decode error when the remote host sends non-UTF-8 content without declaring a charset (such as sensor firmware that serves the degree sign as a raw Latin-1 byte). The response is read as Latin-1 in that case instead of aborting the check.
+
 
 ## [v5.1.0] - 2026-06-24
 

--- a/tests/url/unit-test/run
+++ b/tests/url/unit-test/run
@@ -476,6 +476,18 @@ class TestFetchSuccess(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(res, 'über')
 
+    def test_undeclared_charset_falls_back_to_latin1(self):
+        # Comet System Web Sensors serve ° as the raw Latin-1 byte 0xb0 and
+        # declare no charset. Strict UTF-8 would raise on 0xb0; without a
+        # declared charset lib.url must fall back to Latin-1 rather than fail.
+        fake, _ = make_fake_client(
+            FakeStreamResponse(body=b'25.3 \xb0C', charset_encoding=None)
+        )
+        with patch_client(fake):
+            ok, res = url.fetch('https://example.com')
+        self.assertTrue(ok)
+        self.assertEqual(res, '25.3 °C')
+
     def test_no_proxy_disables_trust_env(self):
         fake, cap = make_fake_client(FakeStreamResponse())
         with patch_client(fake):

--- a/url.py
+++ b/url.py
@@ -11,7 +11,7 @@
 """Get for example HTML or JSON from an URL."""
 
 __author__ = 'Linuxfabrik GmbH, Zurich/Switzerland'
-__version__ = '2026061901'
+__version__ = '2026070301'
 
 import base64
 import json
@@ -537,7 +537,21 @@ def fetch(
 
     try:
         charset = response_charset or 'UTF-8'
-        body_decoded = body_bytes.decode(charset) if to_text else body_bytes
+        if to_text:
+            try:
+                body_decoded = body_bytes.decode(charset)
+            except UnicodeDecodeError:
+                if response_charset:
+                    # The server explicitly declared this charset, so a mismatch
+                    # is a genuine error and must surface to the caller.
+                    raise
+                # No charset header was sent and our UTF-8 assumption was wrong.
+                # Latin-1 maps every byte 1:1 and never fails, preserving bytes
+                # like 0xb0 (° in ISO-8859-1) emitted by sensor firmware that
+                # serves non-UTF-8 content without a charset header.
+                body_decoded = body_bytes.decode('latin-1')
+        else:
+            body_decoded = body_bytes
 
         if not extended:
             return success, body_decoded


### PR DESCRIPTION
## Problem

`url.fetch()` decodes every response body as strict UTF-8 when the server sends no charset (`response_charset` is `None` → default `'UTF-8'`). A single non-UTF-8 byte then aborts the whole check with a `UnicodeDecodeError`.

Real-world trigger: Comet System Web Sensors serve the degree sign `°` as the raw ISO-8859-1 byte `0xb0` in their `values.json` and declare no charset, so `cometsystem` fails with:

```
'utf-8' codec can't decode byte 0xb0 in position 164: invalid start byte while fetching http://.../values.json
```

This is a regression from the pre-`httpx` engine (lib 3.x), which decoded tolerantly.

## Fix

When the server declared **no** charset and the UTF-8 assumption fails, fall back to Latin-1, which maps every byte `0x00`–`0xFF` one-to-one and can never raise. `0xb0` becomes `°`, which is what the firmware means.

A charset the server **explicitly** declared still fails on mismatch, so genuine encoding errors are not masked (the existing `test_decode_error_returns_failure` guards this).

### Why Latin-1 and not `surrogateescape`

The plugins decode a body, build a message, and print it to stdout (re-encoding to UTF-8). Tested against the byte values seen across the monitoring-plugins decode issues (`0xb0`, `0x81`, `0xc2`, `0xfc`):

| bytes | latin-1 → output | surrogateescape → output |
|---|---|---|
| `25.3 \xb0C` | `25.3 °C` OK | `\udcb0` **UnicodeEncodeError** |
| `>m\x81ller` | OK | **UnicodeEncodeError** |
| `M\xfcller` | `Müller` OK | **UnicodeEncodeError** |

`surrogateescape` only relocates the crash from fetch to output. Latin-1 maps to real Unicode scalars that survive both the JSON round-trip and the stdout re-encode. This matches how the lib already fixed the Windows console decode crashes (`shell.py` decodes with the actual OEM code page rather than papering over a wrong-codec decode with an error handler).

## Tests

* New `test_undeclared_charset_falls_back_to_latin1` reproduces the cometsystem case (body `b'25.3 \xb0C'`, no charset → `'25.3 °C'`).
* Existing `test_decode_error_returns_failure` stays valid: a declared charset with invalid bytes still fails.

Full `tests/url` suite green (90 tests), `ruff check`/`ruff format` clean.

Fixes the `cometsystem` decode failure reported downstream in Linuxfabrik/monitoring-plugins.