### PR TITLE
chore: unify pyproject.toml across repositories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ Tracker = "https://github.com/Linuxfabrik/lib/issues"
 Download = "https://github.com/Linuxfabrik/lib/releases"
 
 [tool.ruff]
+line-length = 88
 target-version = 'py39'
 
 [tool.ruff.lint]
@@ -83,8 +84,8 @@ ignore = [
 ]
 
 [tool.ruff.format]
-quote-style = 'single'
 docstring-code-format = true
+quote-style = 'single'
 
 [tool.bandit]
 # B110 (try/except/pass) and B112 (try/except/continue): intentional patterns
@@ -96,9 +97,9 @@ skips = ['B110', 'B112', 'B311']
 # packages are not in the root of the repository or do not correspond exactly to
 # the directory structure, so we need to configure package_dir
 # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
-package-dir = {"lib" = "."}
+package-dir = {'lib' = '.'}
 # Declare the package explicitly. Without this, setuptools auto-discovery walks
 # the repository root with followlinks=True. The per-module `tests/*/lib`
 # symlinks point back to the root, so the walk recurses through them endlessly
 # and the build hangs. There is a single flat `lib` package, so list it directly.
-packages = ["lib"]
+packages = ['lib']

--- a/tests/db_sqlite/unit-test/run
+++ b/tests/db_sqlite/unit-test/run
@@ -44,7 +44,9 @@ class TestGetDbDir(unittest.TestCase):
     def test_creates_private_0700_directory_owned_by_user(self):
         ok, db_dir = db.get_db_dir(self.base)
         self.assertTrue(ok, db_dir)
-        self.assertTrue(db_dir.endswith(f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}'))
+        self.assertTrue(
+            db_dir.endswith(f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}')
+        )
         st = os.lstat(db_dir)
         self.assertTrue(stat.S_ISDIR(st.st_mode))
         self.assertEqual(st.st_uid, os.geteuid())
@@ -59,7 +61,9 @@ class TestGetDbDir(unittest.TestCase):
 
     @unittest.skipUnless(HAS_GETEUID, 'POSIX-only hardening')
     def test_rejects_symlink(self):
-        link = os.path.join(self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}')
+        link = os.path.join(
+            self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}'
+        )
         os.symlink('/nonexistent/attacker/target', link)
         ok, msg = db.get_db_dir(self.base)
         self.assertFalse(ok)
@@ -67,7 +71,9 @@ class TestGetDbDir(unittest.TestCase):
 
     @unittest.skipUnless(HAS_GETEUID, 'POSIX-only hardening')
     def test_rejects_group_or_world_accessible_directory(self):
-        db_dir = os.path.join(self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}')
+        db_dir = os.path.join(
+            self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}'
+        )
         os.mkdir(db_dir, 0o755)
         ok, msg = db.get_db_dir(self.base)
         self.assertFalse(ok)
@@ -120,7 +126,9 @@ class TestConnect(unittest.TestCase):
 
     @unittest.skipUnless(HAS_GETEUID, 'POSIX-only hardening')
     def test_connect_refuses_symlinked_dir(self):
-        link = os.path.join(self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}')
+        link = os.path.join(
+            self.base, f'linuxfabrik-monitoring-plugins-uid{os.geteuid()}'
+        )
         os.symlink('/nonexistent', link)
         ok, msg = db.connect(path=self.base, filename='t.db')
         self.assertFalse(ok)
@@ -139,8 +147,13 @@ class TestCrud(unittest.TestCase):
         db.close(self.conn)
 
     def test_create_insert_select(self):
-        self.assertEqual(db.create_table(self.conn, 'a TEXT, b INTEGER NOT NULL', table='t'), (True, True))
-        self.assertEqual(db.insert(self.conn, {'a': 'x', 'b': 1}, table='t'), (True, True))
+        self.assertEqual(
+            db.create_table(self.conn, 'a TEXT, b INTEGER NOT NULL', table='t'),
+            (True, True),
+        )
+        self.assertEqual(
+            db.insert(self.conn, {'a': 'x', 'b': 1}, table='t'), (True, True)
+        )
         db.commit(self.conn)
         ok, rows = db.select(self.conn, 'SELECT a, b FROM t')
         self.assertTrue(ok)
@@ -207,7 +220,9 @@ class TestPureHelpers(unittest.TestCase):
 
     def test_sha1sum_docstring_example(self):
         sha1sum = getattr(db, '__sha1sum')
-        self.assertEqual(sha1sum('linuxfabrik'), '74301e766db4a4006ec1fbd6e031760e7e322223')
+        self.assertEqual(
+            sha1sum('linuxfabrik'), '74301e766db4a4006ec1fbd6e031760e7e322223'
+        )
 
     def test_filter_str_strips_unsafe_chars(self):
         filter_str = getattr(db, '__filter_str')
@@ -264,8 +279,12 @@ class TestPerSecondDeltas(unittest.TestCase):
         ticks = iter([1000, 1010])
         db.time.now = lambda: next(ticks)
         try:
-            first = db.per_second_deltas('lftest-psd-rate.db', 'eth0', {'rx_bytes': 100})
-            rates = db.per_second_deltas('lftest-psd-rate.db', 'eth0', {'rx_bytes': 300})
+            first = db.per_second_deltas(
+                'lftest-psd-rate.db', 'eth0', {'rx_bytes': 100}
+            )
+            rates = db.per_second_deltas(
+                'lftest-psd-rate.db', 'eth0', {'rx_bytes': 300}
+            )
         finally:
             db.time.now = saved_now
         self.assertIsNone(first)

--- a/tests/disk/unit-test/run
+++ b/tests/disk/unit-test/run
@@ -37,7 +37,9 @@ class TestFileHelpers(unittest.TestCase):
 
     def test_read_file_binary(self):
         disk.write_file(self.file, 'héllo')
-        self.assertEqual(disk.read_file(self.file, binary=True), (True, 'héllo'.encode()))
+        self.assertEqual(
+            disk.read_file(self.file, binary=True), (True, 'héllo'.encode())
+        )
 
     def test_write_append(self):
         disk.write_file(self.file, 'a')
@@ -149,14 +151,18 @@ class TestFileHelpers(unittest.TestCase):
         self.assertEqual(disk.grep_file(self.file, 'he(l+)o'), (True, 'll'))
 
     def test_is_within_containment_and_escape(self):
-        self.assertTrue(disk.is_within(os.path.join(self.dir, 'sub', 'a.log'), [self.dir]))
+        self.assertTrue(
+            disk.is_within(os.path.join(self.dir, 'sub', 'a.log'), [self.dir])
+        )
         self.assertTrue(disk.is_within(self.dir, [self.dir]))
         # `..` cannot climb out of the root
         self.assertFalse(disk.is_within(os.path.join(self.dir, '..', 'x'), [self.dir]))
         # a sibling sharing the name prefix must not match
         self.assertFalse(disk.is_within(self.dir + 'x', [self.dir]))
         # first matching root of several wins
-        self.assertTrue(disk.is_within('/var/lib/mysql/h.err', ['/var/log', '/var/lib/mysql']))
+        self.assertTrue(
+            disk.is_within('/var/lib/mysql/h.err', ['/var/log', '/var/lib/mysql'])
+        )
 
     def test_is_within_resolves_symlink_out_of_root(self):
         # A symlink inside the root pointing outside is rejected: this is why an
@@ -330,7 +336,9 @@ class TestShortenPath(unittest.TestCase):
         self.assertEqual(disk.shorten_path('/'), '/')
 
     def test_max_len_leaves_short_path_untouched(self):
-        self.assertEqual(disk.shorten_path('/var/log/audit', max_len=40), '/var/log/audit')
+        self.assertEqual(
+            disk.shorten_path('/var/log/audit', max_len=40), '/var/log/audit'
+        )
 
     def test_max_len_abbreviates_when_over_limit(self):
         # abbreviating the parents is enough; no truncation needed.
@@ -358,8 +366,12 @@ class TestShortenPath(unittest.TestCase):
             '/var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.rbd.csi.ceph.com/'
             '{h}/globalmount/0001-0009-rook-ceph-{s}'
         )
-        a = base.format(h='6f75297b4f41d9dc95027a8d7d09ea1edfd84d05', s='000000000000000b-ef18f2fa')
-        b = base.format(h='79eba44fbcb484b29e9911328f58aba5e936f8b4', s='000000000000000c-1bf231b1')
+        a = base.format(
+            h='6f75297b4f41d9dc95027a8d7d09ea1edfd84d05', s='000000000000000b-ef18f2fa'
+        )
+        b = base.format(
+            h='79eba44fbcb484b29e9911328f58aba5e936f8b4', s='000000000000000c-1bf231b1'
+        )
         self.assertNotEqual(
             disk.shorten_path(a, max_len=40),
             disk.shorten_path(b, max_len=40),

--- a/tests/distro/unit-test/run
+++ b/tests/distro/unit-test/run
@@ -208,9 +208,7 @@ class TestParseDistributionFile(unittest.TestCase):
         self.assertEqual(facts['distribution'], 'Altlinux')
 
     def test_smgl_search_string(self):
-        ok, facts = distro._parse_distribution_file(
-            'SMGL', 'Source Mage GNU/Linux x\n'
-        )
+        ok, facts = distro._parse_distribution_file('SMGL', 'Source Mage GNU/Linux x\n')
         self.assertTrue(ok)
         self.assertEqual(facts['distribution'], 'SMGL')
 
@@ -300,16 +298,18 @@ class TestParseOsRelease(unittest.TestCase):
     """_parse_os_release: VERSION_ID extraction."""
 
     def test_ubuntu_version(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', return_value=OS_RELEASE_UBUNTU
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', return_value=OS_RELEASE_UBUNTU),
         ):
             facts = distro._parse_os_release('/etc/os-release')
         self.assertEqual(facts['distribution_version'], '22.04')
         self.assertEqual(facts['distribution_major_version'], '22')
 
     def test_fedora_version_unquoted(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', return_value=OS_RELEASE_FEDORA
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', return_value=OS_RELEASE_FEDORA),
         ):
             facts = distro._parse_os_release('/etc/os-release')
         self.assertEqual(facts['distribution_version'], '41')
@@ -320,14 +320,16 @@ class TestParseOsRelease(unittest.TestCase):
             self.assertEqual(distro._parse_os_release('/etc/os-release'), {})
 
     def test_read_exception_returns_empty(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', side_effect=OSError('boom')
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', side_effect=OSError('boom')),
         ):
             self.assertEqual(distro._parse_os_release('/etc/os-release'), {})
 
     def test_no_version_id_returns_empty(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', return_value='ID=foo\n'
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', return_value='ID=foo\n'),
         ):
             self.assertEqual(distro._parse_os_release('/etc/os-release'), {})
 
@@ -336,8 +338,9 @@ class TestParseLsbRelease(unittest.TestCase):
     """_parse_lsb_release: DISTRIB_RELEASE extraction."""
 
     def test_release_extracted(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', return_value=LSB_RELEASE
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', return_value=LSB_RELEASE),
         ):
             facts = distro._parse_lsb_release('/etc/lsb-release')
         self.assertEqual(facts['distribution_version'], '20.04')
@@ -348,14 +351,18 @@ class TestParseLsbRelease(unittest.TestCase):
             self.assertEqual(distro._parse_lsb_release('/etc/lsb-release'), {})
 
     def test_read_exception_returns_empty(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', side_effect=OSError('boom')
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch('lib.distro._get_file_content', side_effect=OSError('boom')),
         ):
             self.assertEqual(distro._parse_lsb_release('/etc/lsb-release'), {})
 
     def test_no_release_line_returns_empty(self):
-        with mock.patch('lib.distro._file_exists', return_value=True), mock.patch(
-            'lib.distro._get_file_content', return_value='DISTRIB_ID=Ubuntu\n'
+        with (
+            mock.patch('lib.distro._file_exists', return_value=True),
+            mock.patch(
+                'lib.distro._get_file_content', return_value='DISTRIB_ID=Ubuntu\n'
+            ),
         ):
             self.assertEqual(distro._parse_lsb_release('/etc/lsb-release'), {})
 
@@ -364,7 +371,14 @@ class TestMapOsFamily(unittest.TestCase):
     """_map_os_family: distribution -> os_family mapping."""
 
     def test_redhat_family_members(self):
-        for member in ('RedHat', 'CentOS', 'Fedora', 'OracleLinux', 'Rocky', 'AlmaLinux'):
+        for member in (
+            'RedHat',
+            'CentOS',
+            'Fedora',
+            'OracleLinux',
+            'Rocky',
+            'AlmaLinux',
+        ):
             self.assertEqual(distro._map_os_family(member), 'RedHat')
 
     def test_debian_family_members(self):
@@ -408,12 +422,14 @@ class TestProcessDistFiles(unittest.TestCase):
         def fake_get_content(path):
             return files[path]
 
-        with mock.patch('lib.distro.os.path.isfile', side_effect=fake_isfile), \
-             mock.patch('lib.distro.os.path.getsize', side_effect=fake_getsize), \
-             mock.patch('lib.distro._get_file_content', side_effect=fake_get_content), \
-             mock.patch('lib.distro.platform.system', return_value='Linux'), \
-             mock.patch('lib.distro.platform.version', return_value='5.0.0'), \
-             mock.patch('lib.distro.platform.release', return_value='5.0.0-x'):
+        with (
+            mock.patch('lib.distro.os.path.isfile', side_effect=fake_isfile),
+            mock.patch('lib.distro.os.path.getsize', side_effect=fake_getsize),
+            mock.patch('lib.distro._get_file_content', side_effect=fake_get_content),
+            mock.patch('lib.distro.platform.system', return_value='Linux'),
+            mock.patch('lib.distro.platform.version', return_value='5.0.0'),
+            mock.patch('lib.distro.platform.release', return_value='5.0.0-x'),
+        ):
             return distro._process_dist_files()
 
     def test_redhat_release_detected(self):
@@ -493,12 +509,14 @@ class TestProcessDistFiles(unittest.TestCase):
                 raise OSError('unreadable')
             return OS_RELEASE_UBUNTU
 
-        with mock.patch('lib.distro.os.path.isfile', side_effect=fake_isfile), \
-             mock.patch('lib.distro.os.path.getsize', side_effect=fake_getsize), \
-             mock.patch('lib.distro._get_file_content', side_effect=fake_get_content), \
-             mock.patch('lib.distro.platform.system', return_value='Linux'), \
-             mock.patch('lib.distro.platform.version', return_value='5.0.0'), \
-             mock.patch('lib.distro.platform.release', return_value='5.0.0-x'):
+        with (
+            mock.patch('lib.distro.os.path.isfile', side_effect=fake_isfile),
+            mock.patch('lib.distro.os.path.getsize', side_effect=fake_getsize),
+            mock.patch('lib.distro._get_file_content', side_effect=fake_get_content),
+            mock.patch('lib.distro.platform.system', return_value='Linux'),
+            mock.patch('lib.distro.platform.version', return_value='5.0.0'),
+            mock.patch('lib.distro.platform.release', return_value='5.0.0-x'),
+        ):
             facts = distro._process_dist_files()
         # redhat-release was skipped, os-release ('Debian' variety) matched.
         self.assertEqual(facts['distribution_file_variety'], 'Debian')
@@ -517,9 +535,7 @@ class TestGetDistributionFacts(unittest.TestCase):
             return io.StringIO(os_release)
 
         with (
-            mock.patch(
-                'lib.distro._process_dist_files', return_value=dict(dist_facts)
-            ),
+            mock.patch('lib.distro._process_dist_files', return_value=dict(dist_facts)),
             mock.patch('builtins.open', side_effect=fake_open),
         ):
             facts = distro.get_distribution_facts()

--- a/tests/dmidecode/unit-test/run
+++ b/tests/dmidecode/unit-test/run
@@ -390,13 +390,13 @@ class TestRam(unittest.TestCase):
 
     def test_total_ram_gb(self):
         # Two identical 16 GB DIMMs dedupe to one record, so ram() sees 16 GB.
-        self.assertEqual(dmidecode.ram(self.dmi), 16 * 1024 ** 3)
+        self.assertEqual(dmidecode.ram(self.dmi), 16 * 1024**3)
 
     def test_ram_mb_slot(self):
         dmi = {
             ('h', '17', '1'): {'dmitype': 17, 'Size': '512 MB'},
         }
-        self.assertEqual(dmidecode.ram(dmi), 512 * 1024 ** 2)
+        self.assertEqual(dmidecode.ram(dmi), 512 * 1024**2)
 
     def test_ram_no_modules_zero(self):
         self.assertEqual(dmidecode.ram({}), 0)
@@ -412,7 +412,7 @@ class TestRam(unittest.TestCase):
             ('a', '17', '1'): {'dmitype': 17, 'Size': '8 GB'},
             ('b', '17', '1'): {'dmitype': 17, 'Size': '2048 MB'},
         }
-        self.assertEqual(dmidecode.ram(dmi), 8 * 1024 ** 3 + 2048 * 1024 ** 2)
+        self.assertEqual(dmidecode.ram(dmi), 8 * 1024**3 + 2048 * 1024**2)
 
 
 class TestGetData(unittest.TestCase):

--- a/tests/feedparser/unit-test/run
+++ b/tests/feedparser/unit-test/run
@@ -99,6 +99,7 @@ def rss_soup(xml=RSS_FEED):
 # parse() - orchestration + dispatch. lib.url.fetch is patched out.
 # ----------------------------------------------------------------------------
 
+
 @unittest.skipUnless(HAVE_DEPS, 'BeautifulSoup4 not installed: ' + IMPORT_ERROR)
 class TestParse(unittest.TestCase):
     """parse() fetch handling, format detection and dispatch."""
@@ -133,16 +134,20 @@ class TestParse(unittest.TestCase):
 
     def test_dispatches_to_parse_atom(self):
         # Format detection must route Atom payloads through parse_atom().
-        with patch.object(feedparser.url, 'fetch', return_value=(True, ATOM_FEED)), \
-                patch.object(feedparser, 'parse_atom', return_value={'k': 'atom'}) as m:
+        with (
+            patch.object(feedparser.url, 'fetch', return_value=(True, ATOM_FEED)),
+            patch.object(feedparser, 'parse_atom', return_value={'k': 'atom'}) as m,
+        ):
             ok, result = feedparser.parse('https://x/atom')
         self.assertTrue(ok)
         self.assertEqual(result, {'k': 'atom'})
         m.assert_called_once()
 
     def test_dispatches_to_parse_rss(self):
-        with patch.object(feedparser.url, 'fetch', return_value=(True, RSS_FEED)), \
-                patch.object(feedparser, 'parse_rss', return_value={'k': 'rss'}) as m:
+        with (
+            patch.object(feedparser.url, 'fetch', return_value=(True, RSS_FEED)),
+            patch.object(feedparser, 'parse_rss', return_value={'k': 'rss'}) as m,
+        ):
             ok, result = feedparser.parse('https://x/rss')
         self.assertTrue(ok)
         self.assertEqual(result, {'k': 'rss'})
@@ -178,6 +183,7 @@ class TestParse(unittest.TestCase):
 # ----------------------------------------------------------------------------
 # parse_atom()
 # ----------------------------------------------------------------------------
+
 
 @unittest.skipUnless(HAVE_DEPS, 'BeautifulSoup4 not installed: ' + IMPORT_ERROR)
 class TestParseAtom(unittest.TestCase):
@@ -278,6 +284,7 @@ class TestParseAtom(unittest.TestCase):
 # ----------------------------------------------------------------------------
 # parse_rss()
 # ----------------------------------------------------------------------------
+
 
 @unittest.skipUnless(HAVE_DEPS, 'BeautifulSoup4 not installed: ' + IMPORT_ERROR)
 class TestParseRss(unittest.TestCase):

--- a/tests/globals/unit-test/run
+++ b/tests/globals/unit-test/run
@@ -20,7 +20,9 @@ import lib.globals as g
 
 class TestStateConstants(unittest.TestCase):
     def test_nagios_state_values(self):
-        self.assertEqual((g.STATE_OK, g.STATE_WARN, g.STATE_CRIT, g.STATE_UNKNOWN), (0, 1, 2, 3))
+        self.assertEqual(
+            (g.STATE_OK, g.STATE_WARN, g.STATE_CRIT, g.STATE_UNKNOWN), (0, 1, 2, 3)
+        )
 
 
 if __name__ == '__main__':

--- a/tests/grassfish/unit-test/run
+++ b/tests/grassfish/unit-test/run
@@ -119,7 +119,9 @@ class TestFetchJsonRequestBuilding(unittest.TestCase):
             'func': 'devices',
         }
         defaults.update(kwargs)
-        with mock.patch.object(grassfish.url, 'fetch_json', side_effect=fake_fetch_json):
+        with mock.patch.object(
+            grassfish.url, 'fetch_json', side_effect=fake_fetch_json
+        ):
             result = grassfish.fetch_json(**defaults)
         return captured, result
 
@@ -234,7 +236,9 @@ class TestFetchJsonResponseHandling(unittest.TestCase):
         self.assertEqual(self._run((True, 'pong')), (True, 'pong'))
 
     def test_transport_failure_passthrough(self):
-        self.assertEqual(self._run((False, 'connection refused')), (False, 'connection refused'))
+        self.assertEqual(
+            self._run((False, 'connection refused')), (False, 'connection refused')
+        )
 
     def test_transport_failure_short_circuits_before_empty_check(self):
         # A failure with a falsy message must still surface as (False, message),
@@ -273,9 +277,13 @@ class TestFetchJsonResponseHandling(unittest.TestCase):
 
     def test_error_message_contains_full_url(self):
         with mock.patch.object(grassfish.url, 'fetch_json', return_value=(True, {})):
-            ok, msg = grassfish.fetch_json('t', 'ds.example.com', 8443, '/gv2', 2, 'Screens')
+            ok, msg = grassfish.fetch_json(
+                't', 'ds.example.com', 8443, '/gv2', 2, 'Screens'
+            )
         self.assertFalse(ok)
-        self.assertEqual(msg, 'There was no result from https://ds.example.com:8443/gv2/v2/Screens.')
+        self.assertEqual(
+            msg, 'There was no result from https://ds.example.com:8443/gv2/v2/Screens.'
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -291,7 +299,9 @@ class TestSetPlayerDefaults(unittest.TestCase):
         self.assertEqual(set(result.keys()), EXPECTED_PLAYER_FIELDS)
 
     def test_empty_dict_field_count(self):
-        self.assertEqual(len(grassfish.set_player_defaults({})), len(EXPECTED_PLAYER_FIELDS))
+        self.assertEqual(
+            len(grassfish.set_player_defaults({})), len(EXPECTED_PLAYER_FIELDS)
+        )
 
     def test_missing_fields_default_to_none(self):
         result = grassfish.set_player_defaults({})
@@ -371,7 +381,9 @@ class TestSetScreenDefaults(unittest.TestCase):
         self.assertEqual(set(result.keys()), EXPECTED_SCREEN_FIELDS)
 
     def test_empty_dict_field_count(self):
-        self.assertEqual(len(grassfish.set_screen_defaults({})), len(EXPECTED_SCREEN_FIELDS))
+        self.assertEqual(
+            len(grassfish.set_screen_defaults({})), len(EXPECTED_SCREEN_FIELDS)
+        )
 
     def test_missing_fields_default_to_none(self):
         result = grassfish.set_screen_defaults({})
@@ -433,7 +445,9 @@ class TestFetchAndNormalize(unittest.TestCase):
 
     def test_players_endpoint_then_normalize(self):
         payload = load_fixture('players.json')
-        with mock.patch.object(grassfish.url, 'fetch_json', return_value=(True, payload)):
+        with mock.patch.object(
+            grassfish.url, 'fetch_json', return_value=(True, payload)
+        ):
             ok, result = grassfish.fetch_json(
                 'tok', 'ds.example.com', 443, '/gv2/webservices/API', 1, 'Players'
             )
@@ -444,7 +458,9 @@ class TestFetchAndNormalize(unittest.TestCase):
 
     def test_screens_endpoint_then_normalize(self):
         payload = load_fixture('screens.json')
-        with mock.patch.object(grassfish.url, 'fetch_json', return_value=(True, payload)):
+        with mock.patch.object(
+            grassfish.url, 'fetch_json', return_value=(True, payload)
+        ):
             ok, result = grassfish.fetch_json(
                 'tok', 'ds.example.com', 443, '/gv2/webservices/API', 1, 'Screens'
             )

--- a/tests/infomaniak/unit-test/run
+++ b/tests/infomaniak/unit-test/run
@@ -128,6 +128,7 @@ SLOTS_SUCCESS = {
 # Helpers
 # -----------------------------------------------------------------------------
 
+
 def ok(payload):
     """Build the (success, body) tuple lib.url.fetch_json returns on HTTP 200."""
     return (True, payload)
@@ -180,6 +181,7 @@ class InfomaniakTestCase(unittest.TestCase):
 # Module surface / constants
 # -----------------------------------------------------------------------------
 
+
 class TestModuleSurface(InfomaniakTestCase):
     def test_base_url(self):
         self.assertEqual(infomaniak.BASE_URL, 'https://api.infomaniak.com')
@@ -199,6 +201,7 @@ class TestModuleSurface(InfomaniakTestCase):
 # -----------------------------------------------------------------------------
 # get_events
 # -----------------------------------------------------------------------------
+
 
 class TestGetEvents(InfomaniakTestCase):
     def test_success_returns_payload(self):
@@ -251,8 +254,7 @@ class TestGetEvents(InfomaniakTestCase):
         self.assertFalse(success)
         self.assertEqual(
             result,
-            'There was no result from '
-            'https://api.infomaniak.com/2/events?locale=en.',
+            'There was no result from https://api.infomaniak.com/2/events?locale=en.',
         )
 
     def test_api_error_with_description(self):
@@ -282,6 +284,7 @@ class TestGetEvents(InfomaniakTestCase):
 # -----------------------------------------------------------------------------
 # get_swiss_backup_products
 # -----------------------------------------------------------------------------
+
 
 class TestGetSwissBackupProducts(InfomaniakTestCase):
     def test_success_returns_payload(self):
@@ -317,7 +320,11 @@ class TestGetSwissBackupProducts(InfomaniakTestCase):
     def test_custom_kwargs_forwarded(self):
         m = self.patch_fetch(ok(PRODUCTS_SUCCESS))
         infomaniak.get_swiss_backup_products(
-            'ACC', 'TOK', insecure=True, no_proxy=True, timeout=20,
+            'ACC',
+            'TOK',
+            insecure=True,
+            no_proxy=True,
+            timeout=20,
         )
         kwargs = m.call_args.kwargs
         self.assertTrue(kwargs['insecure'])
@@ -363,6 +370,7 @@ class TestGetSwissBackupProducts(InfomaniakTestCase):
 # get_swiss_backup_slots
 # -----------------------------------------------------------------------------
 
+
 class TestGetSwissBackupSlots(InfomaniakTestCase):
     def _two_products_side_effect(self):
         """Side effect: first call -> products, subsequent -> a fresh slot.
@@ -370,6 +378,7 @@ class TestGetSwissBackupSlots(InfomaniakTestCase):
         Every slot call returns an independent payload so the module's in-place
         enrichment cannot bleed across products.
         """
+
         def side(uri, **kwargs):
             if 'account_id' in uri:
                 return ok(PRODUCTS_SUCCESS)
@@ -431,7 +440,11 @@ class TestGetSwissBackupSlots(InfomaniakTestCase):
     def test_slot_fetch_forwards_custom_kwargs(self):
         m = self.patch_fetch(side_effect=self._two_products_side_effect())
         infomaniak.get_swiss_backup_slots(
-            'ACC', 'TOK', insecure=True, no_proxy=True, timeout=99,
+            'ACC',
+            'TOK',
+            insecure=True,
+            no_proxy=True,
+            timeout=99,
         )
         # The slot fetch (2nd call onward) forwards the caller's kwargs.
         slot_call = m.call_args_list[1]
@@ -446,7 +459,11 @@ class TestGetSwissBackupSlots(InfomaniakTestCase):
         # it always uses the function defaults.
         m = self.patch_fetch(side_effect=self._two_products_side_effect())
         infomaniak.get_swiss_backup_slots(
-            'ACC', 'TOK', insecure=True, no_proxy=True, timeout=99,
+            'ACC',
+            'TOK',
+            insecure=True,
+            no_proxy=True,
+            timeout=99,
         )
         products_call = m.call_args_list[0]
         self.assertFalse(products_call.kwargs['insecure'])

--- a/tests/jitsi/unit-test/run
+++ b/tests/jitsi/unit-test/run
@@ -123,25 +123,34 @@ class TestDispatch(unittest.TestCase):
     """get_data() picks url.fetch_json for _type='json', url.fetch otherwise."""
 
     def test_default_type_uses_fetch_json(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj, \
-             mock.patch.object(jitsi.url, 'fetch') as f:
+        with (
+            mock.patch.object(
+                jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+            ) as fj,
+            mock.patch.object(jitsi.url, 'fetch') as f,
+        ):
             jitsi.get_data(make_args())
             self.assertTrue(fj.called)
             self.assertFalse(f.called)
 
     def test_explicit_json_uses_fetch_json(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj, \
-             mock.patch.object(jitsi.url, 'fetch') as f:
+        with (
+            mock.patch.object(
+                jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+            ) as fj,
+            mock.patch.object(jitsi.url, 'fetch') as f,
+        ):
             jitsi.get_data(make_args(), _type='json')
             self.assertTrue(fj.called)
             self.assertFalse(f.called)
 
     def test_raw_type_uses_fetch(self):
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(True, FETCH_RAW_EXTENDED_OK)) as f, \
-             mock.patch.object(jitsi.url, 'fetch_json') as fj:
+        with (
+            mock.patch.object(
+                jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+            ) as f,
+            mock.patch.object(jitsi.url, 'fetch_json') as fj,
+        ):
             jitsi.get_data(make_args(), _type='raw')
             self.assertTrue(f.called)
             self.assertFalse(fj.called)
@@ -151,19 +160,25 @@ class TestDispatch(unittest.TestCase):
         for _type in ('text', 'html', 'xml', '', 'JSON', 'Json', 'json '):
             with (
                 self.subTest(_type=_type),
-                mock.patch.object(jitsi.url, 'fetch',
-                                  return_value=(True, FETCH_RAW_EXTENDED_OK)) as f,
+                mock.patch.object(
+                    jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+                ) as f,
                 mock.patch.object(jitsi.url, 'fetch_json') as fj,
             ):
                 jitsi.get_data(make_args(), _type=_type)
                 self.assertTrue(f.called, f'_type={_type!r} should use fetch')
-                self.assertFalse(fj.called, f'_type={_type!r} should not use fetch_json')
+                self.assertFalse(
+                    fj.called, f'_type={_type!r} should not use fetch_json'
+                )
 
     def test_type_match_is_case_sensitive(self):
         # 'json' matches, 'JSON' does not. Documents the exact == 'json' check.
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(True, FETCH_RAW_EXTENDED_OK)) as f, \
-             mock.patch.object(jitsi.url, 'fetch_json') as fj:
+        with (
+            mock.patch.object(
+                jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+            ) as f,
+            mock.patch.object(jitsi.url, 'fetch_json') as fj,
+        ):
             jitsi.get_data(make_args(), _type='JSON')
             self.assertTrue(f.called)
             self.assertFalse(fj.called)
@@ -179,22 +194,25 @@ class TestRequestConstruction(unittest.TestCase):
 
     def test_url_passed_positionally(self):
         url_value = 'https://198.51.100.5:8080/colibri/stats'
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(url=url_value))
             self.assertEqual(fj.call_args.args, (url_value,))
 
     def test_extended_always_true(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args())
             self.assertIs(fj.call_args.kwargs['extended'], True)
 
     def test_kwargs_forwarded_from_args(self):
         # insecure / no_proxy / timeout flow straight through from args.
         args = make_args(timeout=30, insecure=True, no_proxy=True)
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(args)
             kwargs = fj.call_args.kwargs
             self.assertEqual(kwargs['timeout'], 30)
@@ -203,8 +221,9 @@ class TestRequestConstruction(unittest.TestCase):
 
     def test_default_kwargs_forwarded(self):
         args = make_args()  # timeout=8, insecure=False, no_proxy=False
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(args)
             kwargs = fj.call_args.kwargs
             self.assertEqual(kwargs['timeout'], 8)
@@ -213,8 +232,9 @@ class TestRequestConstruction(unittest.TestCase):
 
     def test_exact_kwarg_set(self):
         # Lock the full kwarg contract so a future signature drift is caught.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args())
             self.assertEqual(
                 set(fj.call_args.kwargs.keys()),
@@ -223,8 +243,9 @@ class TestRequestConstruction(unittest.TestCase):
 
     def test_raw_mode_forwards_same_kwargs(self):
         args = make_args(timeout=15, insecure=True, no_proxy=True)
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(True, FETCH_RAW_EXTENDED_OK)) as f:
+        with mock.patch.object(
+            jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+        ) as f:
             jitsi.get_data(args, _type='raw')
             kwargs = f.call_args.kwargs
             self.assertEqual(f.call_args.args, (args.URL,))
@@ -243,21 +264,24 @@ class TestAuthHeader(unittest.TestCase):
     """Header carries Basic Auth only when USERNAME is truthy."""
 
     def test_no_auth_header_without_username(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username='', password=''))
             self.assertEqual(fj.call_args.kwargs['header'], {})
 
     def test_no_auth_header_with_password_but_no_username(self):
         # The guard is on USERNAME only; a lone password yields no header.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username='', password='linuxfabrik'))
             self.assertEqual(fj.call_args.kwargs['header'], {})
 
     def test_auth_header_with_username_and_password(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username='admin', password='linuxfabrik'))
             header = fj.call_args.kwargs['header']
             expected = 'Basic ' + base64.b64encode(b'admin:linuxfabrik').decode()
@@ -265,18 +289,20 @@ class TestAuthHeader(unittest.TestCase):
 
     def test_auth_header_value_is_decodable(self):
         # Round-trip the encoded token back to the original credentials.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username='monitor', password='s3cr3t!'))
             token = fj.call_args.kwargs['header']['Authorization']
             self.assertTrue(token.startswith('Basic '))
-            decoded = base64.b64decode(token[len('Basic '):]).decode()
+            decoded = base64.b64decode(token[len('Basic ') :]).decode()
             self.assertEqual(decoded, 'monitor:s3cr3t!')
 
     def test_auth_header_with_empty_password(self):
         # USERNAME set, PASSWORD empty -> still authenticated, "user:".
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username='u', password=''))
             header = fj.call_args.kwargs['header']
             expected = 'Basic ' + base64.b64encode(b'u:').decode()
@@ -285,19 +311,22 @@ class TestAuthHeader(unittest.TestCase):
     def test_auth_header_handles_unicode_credentials(self):
         # Credentials are UTF-8 encoded before base64; non-ASCII must survive.
         user, pwd = 'tästuser', 'pässwörd'
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args(username=user, password=pwd))
             token = fj.call_args.kwargs['header']['Authorization']
-            decoded = base64.b64decode(token[len('Basic '):]).decode('utf-8')
+            decoded = base64.b64decode(token[len('Basic ') :]).decode('utf-8')
             self.assertEqual(decoded, f'{user}:{pwd}')
 
     def test_auth_header_in_raw_mode(self):
         # Auth handling is independent of _type.
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(True, FETCH_RAW_EXTENDED_OK)) as f:
-            jitsi.get_data(make_args(username='admin', password='linuxfabrik'),
-                           _type='raw')
+        with mock.patch.object(
+            jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+        ) as f:
+            jitsi.get_data(
+                make_args(username='admin', password='linuxfabrik'), _type='raw'
+            )
             header = f.call_args.kwargs['header']
             expected = 'Basic ' + base64.b64encode(b'admin:linuxfabrik').decode()
             self.assertEqual(header, {'Authorization': expected})
@@ -312,8 +341,9 @@ class TestSuccessReturn(unittest.TestCase):
     """On success get_data() returns a 2-tuple (True, result) verbatim."""
 
     def test_json_success_returns_two_tuple(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ):
             result = jitsi.get_data(make_args())
             self.assertEqual(len(result), 2)
             success, payload = result
@@ -321,16 +351,18 @@ class TestSuccessReturn(unittest.TestCase):
             self.assertIs(payload, FETCH_JSON_EXTENDED_OK)
 
     def test_json_success_payload_carries_parsed_document(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ):
             _, payload = jitsi.get_data(make_args())
             self.assertEqual(payload['response_json'], COLIBRI_STATS)
             self.assertEqual(payload['response_json']['conferences'], 2)
             self.assertEqual(payload['status_code'], 200)
 
     def test_raw_success_returns_two_tuple(self):
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(True, FETCH_RAW_EXTENDED_OK)):
+        with mock.patch.object(
+            jitsi.url, 'fetch', return_value=(True, FETCH_RAW_EXTENDED_OK)
+        ):
             result = jitsi.get_data(make_args(), _type='raw')
             self.assertEqual(len(result), 2)
             success, payload = result
@@ -340,8 +372,7 @@ class TestSuccessReturn(unittest.TestCase):
 
     def test_success_with_empty_dict_payload(self):
         # An empty-but-truthy success: fetch_json returned (True, {}).
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, {})):
+        with mock.patch.object(jitsi.url, 'fetch_json', return_value=(True, {})):
             result = jitsi.get_data(make_args())
             self.assertEqual(result, (True, {}))
 
@@ -355,47 +386,52 @@ class TestFailureReturn(unittest.TestCase):
     """On failure get_data() returns a 3-tuple (success, result, False)."""
 
     def test_failure_returns_three_tuple(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, 'Connection refused')):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(False, 'Connection refused')
+        ):
             result = jitsi.get_data(make_args())
             self.assertEqual(len(result), 3)
             self.assertEqual(result, (False, 'Connection refused', False))
 
     def test_failure_first_element_is_falsy(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, 'HTTP 500 Internal Server Error')):
+        with mock.patch.object(
+            jitsi.url,
+            'fetch_json',
+            return_value=(False, 'HTTP 500 Internal Server Error'),
+        ):
             success = jitsi.get_data(make_args())[0]
             self.assertFalse(success)
 
     def test_failure_third_element_is_false(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, 'timeout')):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(False, 'timeout')
+        ):
             self.assertIs(jitsi.get_data(make_args())[2], False)
 
     def test_failure_message_propagated(self):
         msg = 'URL https://192.0.2.10:8080/colibri/stats returned HTTP 404'
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, msg)):
+        with mock.patch.object(jitsi.url, 'fetch_json', return_value=(False, msg)):
             self.assertEqual(jitsi.get_data(make_args())[1], msg)
 
     def test_raw_failure_returns_three_tuple(self):
-        with mock.patch.object(jitsi.url, 'fetch',
-                               return_value=(False, 'TLS handshake failed')):
+        with mock.patch.object(
+            jitsi.url, 'fetch', return_value=(False, 'TLS handshake failed')
+        ):
             result = jitsi.get_data(make_args(), _type='raw')
             self.assertEqual(result, (False, 'TLS handshake failed', False))
 
     def test_failure_with_empty_message(self):
         # An empty error body still trips the not-success branch.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, '')):
+        with mock.patch.object(jitsi.url, 'fetch_json', return_value=(False, '')):
             self.assertEqual(jitsi.get_data(make_args()), (False, '', False))
 
     def test_failure_with_dict_payload(self):
         # lib.url may hand back a dict on a non-200 extended fetch; get_data
         # only checks the success flag, so the payload passes through as-is.
         err_payload = {'status_code': 503, 'response': 'Service Unavailable'}
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, err_payload)):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(False, err_payload)
+        ):
             result = jitsi.get_data(make_args())
             self.assertEqual(result, (False, err_payload, False))
 
@@ -411,8 +447,9 @@ class TestSuccessFlagTruthiness(unittest.TestCase):
     def test_truthy_nonbool_success_takes_success_path(self):
         # A truthy non-True value (e.g. 1) routes to the 2-tuple success path
         # and the returned flag is normalised to literal True.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(1, FETCH_JSON_EXTENDED_OK)):
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(1, FETCH_JSON_EXTENDED_OK)
+        ):
             result = jitsi.get_data(make_args())
             self.assertEqual(len(result), 2)
             self.assertIs(result[0], True)
@@ -420,16 +457,14 @@ class TestSuccessFlagTruthiness(unittest.TestCase):
     def test_falsy_nonbool_success_takes_failure_path(self):
         # A falsy non-False value (0) routes to the 3-tuple failure path and
         # the original flag is preserved as element 0.
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(0, 'err')):
+        with mock.patch.object(jitsi.url, 'fetch_json', return_value=(0, 'err')):
             result = jitsi.get_data(make_args())
             self.assertEqual(len(result), 3)
             self.assertEqual(result[0], 0)
             self.assertIs(result[2], False)
 
     def test_none_success_takes_failure_path(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(None, 'err')):
+        with mock.patch.object(jitsi.url, 'fetch_json', return_value=(None, 'err')):
             result = jitsi.get_data(make_args())
             self.assertEqual(len(result), 3)
             self.assertIsNone(result[0])
@@ -444,14 +479,16 @@ class TestCallCount(unittest.TestCase):
     """get_data() makes exactly one transport call; it does not paginate."""
 
     def test_one_call_on_success(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(True, FETCH_JSON_EXTENDED_OK)) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(True, FETCH_JSON_EXTENDED_OK)
+        ) as fj:
             jitsi.get_data(make_args())
             self.assertEqual(fj.call_count, 1)
 
     def test_one_call_on_failure(self):
-        with mock.patch.object(jitsi.url, 'fetch_json',
-                               return_value=(False, 'err')) as fj:
+        with mock.patch.object(
+            jitsi.url, 'fetch_json', return_value=(False, 'err')
+        ) as fj:
             jitsi.get_data(make_args())
             self.assertEqual(fj.call_count, 1)
 
@@ -468,9 +505,13 @@ class TestModuleSurface(unittest.TestCase):
         self.assertTrue(callable(jitsi.get_data))
 
     def test_only_expected_public_function(self):
-        public = [n for n in dir(jitsi)
-                  if not n.startswith('_') and callable(getattr(jitsi, n))
-                  and getattr(getattr(jitsi, n), '__module__', None) == jitsi.__name__]
+        public = [
+            n
+            for n in dir(jitsi)
+            if not n.startswith('_')
+            and callable(getattr(jitsi, n))
+            and getattr(getattr(jitsi, n), '__module__', None) == jitsi.__name__
+        ]
         self.assertEqual(public, ['get_data'])
 
 

--- a/tests/keycloak/unit-test/run
+++ b/tests/keycloak/unit-test/run
@@ -110,10 +110,11 @@ def make_token_args(**overrides):
 
 
 class TestDiscoverOidcEndpoints(unittest.TestCase):
-
     def test_url_construction_well_known(self):
         args = make_discover_args(URL='https://kc.example.com', REALM='myrealm')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.args[0],
@@ -122,7 +123,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
 
     def test_single_trailing_slash_stripped(self):
         args = make_discover_args(URL='https://kc.example.com/')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.args[0],
@@ -132,7 +135,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_multiple_trailing_slashes_stripped(self):
         # rstrip('/') removes every trailing slash, not just one.
         args = make_discover_args(URL='https://kc.example.com///')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.args[0],
@@ -142,7 +147,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_url_with_path_prefix(self):
         # Reverse-proxied Keycloak under a sub-path.
         args = make_discover_args(URL='https://example.com/auth')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.args[0],
@@ -152,7 +159,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_realm_with_special_characters_passed_through(self):
         # The module does not URL-encode the realm; assert the actual behaviour.
         args = make_discover_args(REALM='my realm/x')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.args[0],
@@ -162,32 +171,42 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_no_auth_header_sent(self):
         # Discovery is unauthenticated: no header kwarg must be passed.
         args = make_discover_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertNotIn('header', m.call_args.kwargs)
         self.assertNotIn('data', m.call_args.kwargs)
 
     def test_passes_insecure_true(self):
         args = make_discover_args(INSECURE=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertIs(m.call_args.kwargs['insecure'], True)
 
     def test_passes_no_proxy_true(self):
         args = make_discover_args(NO_PROXY=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertIs(m.call_args.kwargs['no_proxy'], True)
 
     def test_passes_timeout(self):
         args = make_discover_args(TIMEOUT=42)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(m.call_args.kwargs['timeout'], 42)
 
     def test_all_transport_kwargs_together(self):
         args = make_discover_args(INSECURE=True, NO_PROXY=True, TIMEOUT=15)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(
             m.call_args.kwargs,
@@ -197,7 +216,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_success_payload_returned_verbatim(self):
         fixture = load_fixture('openid-configuration.json')
         args = make_discover_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, fixture)):
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, fixture)
+        ):
             success, result = keycloak.discover_oidc_endpoints(args)
         self.assertTrue(success)
         self.assertEqual(result, fixture)
@@ -209,7 +230,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
     def test_error_non_200_propagated(self):
         args = make_discover_args()
         with mock.patch.object(
-            keycloak.url, 'fetch_json', return_value=(False, 'HTTP 404: Realm not found')
+            keycloak.url,
+            'fetch_json',
+            return_value=(False, 'HTTP 404: Realm not found'),
         ):
             success, result = keycloak.discover_oidc_endpoints(args)
         self.assertFalse(success)
@@ -219,7 +242,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
         # fetch_json reports JSON decode failures as (False, message).
         args = make_discover_args()
         with mock.patch.object(
-            keycloak.url, 'fetch_json', return_value=(False, 'ValueError: No JSON object')
+            keycloak.url,
+            'fetch_json',
+            return_value=(False, 'ValueError: No JSON object'),
         ):
             success, result = keycloak.discover_oidc_endpoints(args)
         self.assertFalse(success)
@@ -234,7 +259,9 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
 
     def test_called_exactly_once(self):
         args = make_discover_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.discover_oidc_endpoints(args)
         self.assertEqual(m.call_count, 1)
 
@@ -245,41 +272,52 @@ class TestDiscoverOidcEndpoints(unittest.TestCase):
 
 
 class TestGetData(unittest.TestCase):
-
     def test_url_concatenation(self):
         args = make_get_data_args(URL='https://kc.example.com')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/admin/serverinfo')
         self.assertEqual(m.call_args.args[0], 'https://kc.example.com/admin/serverinfo')
 
     def test_trailing_slash_on_base_stripped(self):
         args = make_get_data_args(URL='https://kc.example.com/')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/admin/serverinfo')
         self.assertEqual(m.call_args.args[0], 'https://kc.example.com/admin/serverinfo')
 
     def test_multiple_trailing_slashes_on_base_stripped(self):
         args = make_get_data_args(URL='https://kc.example.com///')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertEqual(m.call_args.args[0], 'https://kc.example.com/x')
 
     def test_uri_without_leading_slash_concatenated_literally(self):
         # The module does not insert a separator; document the real behaviour.
         args = make_get_data_args(URL='https://kc.example.com')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, 'admin/serverinfo')
         self.assertEqual(m.call_args.args[0], 'https://kc.example.comadmin/serverinfo')
 
     def test_empty_uri(self):
         args = make_get_data_args(URL='https://kc.example.com')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '')
         self.assertEqual(m.call_args.args[0], 'https://kc.example.com')
 
     def test_bearer_header_built(self):
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'ABC.DEF.GHI'}, '/x')
         self.assertEqual(
             m.call_args.kwargs['header'],
@@ -289,14 +327,18 @@ class TestGetData(unittest.TestCase):
     def test_missing_access_token_yields_empty_bearer(self):
         # token_data without access_token -> "Bearer " (empty), no KeyError.
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {}, '/x')
         self.assertEqual(m.call_args.kwargs['header'], {'Authorization': 'Bearer '})
 
     def test_token_from_fixture(self):
         token_data = load_fixture('token-response.json')
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, token_data, '/admin/serverinfo')
         self.assertEqual(
             m.call_args.kwargs['header']['Authorization'],
@@ -315,31 +357,41 @@ class TestGetData(unittest.TestCase):
     def test_no_data_kwarg_sent(self):
         # get_data performs a GET: no POST body must be passed.
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertNotIn('data', m.call_args.kwargs)
 
     def test_passes_insecure_true(self):
         args = make_get_data_args(INSECURE=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertIs(m.call_args.kwargs['insecure'], True)
 
     def test_passes_no_proxy_true(self):
         args = make_get_data_args(NO_PROXY=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertIs(m.call_args.kwargs['no_proxy'], True)
 
     def test_passes_timeout(self):
         args = make_get_data_args(TIMEOUT=99)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertEqual(m.call_args.kwargs['timeout'], 99)
 
     def test_full_kwargs_shape(self):
         args = make_get_data_args(INSECURE=True, NO_PROXY=True, TIMEOUT=20)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertEqual(
             m.call_args.kwargs,
@@ -354,8 +406,12 @@ class TestGetData(unittest.TestCase):
     def test_success_payload_returned_verbatim(self):
         fixture = load_fixture('serverinfo.json')
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, fixture)):
-            success, result = keycloak.get_data(args, {'access_token': 'TOK'}, '/admin/serverinfo')
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, fixture)
+        ):
+            success, result = keycloak.get_data(
+                args, {'access_token': 'TOK'}, '/admin/serverinfo'
+            )
         self.assertTrue(success)
         self.assertEqual(result, fixture)
         self.assertEqual(result['systemInfo']['version'], '26.0.5')
@@ -382,13 +438,17 @@ class TestGetData(unittest.TestCase):
         # The Admin REST API returns JSON arrays (e.g. /users); a list survives.
         args = make_get_data_args()
         with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, [])):
-            success, result = keycloak.get_data(args, {'access_token': 'TOK'}, '/admin/realms/r/users')
+            success, result = keycloak.get_data(
+                args, {'access_token': 'TOK'}, '/admin/realms/r/users'
+            )
         self.assertTrue(success)
         self.assertEqual(result, [])
 
     def test_called_exactly_once(self):
         args = make_get_data_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.get_data(args, {'access_token': 'TOK'}, '/x')
         self.assertEqual(m.call_count, 1)
 
@@ -399,11 +459,14 @@ class TestGetData(unittest.TestCase):
 
 
 class TestObtainAdminToken(unittest.TestCase):
-
     def test_token_url_built_from_base_url_and_realm(self):
         args = make_token_args(URL='https://kc.example.com', REALM='myrealm')
-        oidc = {'token_endpoint': 'https://kc.example.com/realms/myrealm/protocol/openid-connect/token'}
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        oidc = {
+            'token_endpoint': 'https://kc.example.com/realms/myrealm/protocol/openid-connect/token'
+        }
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, oidc)
         self.assertEqual(
             m.call_args.args[0],
@@ -415,7 +478,9 @@ class TestObtainAdminToken(unittest.TestCase):
         # credentials must still go to the host the operator asked to be monitored.
         args = make_token_args(URL='https://kc.example.com', REALM='myrealm')
         oidc = {'token_endpoint': 'https://attacker.example/collect'}
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, oidc)
         self.assertEqual(
             m.call_args.args[0],
@@ -427,7 +492,9 @@ class TestObtainAdminToken(unittest.TestCase):
         # The same primitive aimed at an internal service instead of an external collector.
         args = make_token_args(URL='https://kc.example.com', REALM='myrealm')
         oidc = {'token_endpoint': 'http://192.0.2.10:8500/v1/kv/creds'}
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, oidc)
         self.assertEqual(
             m.call_args.args[0],
@@ -436,7 +503,9 @@ class TestObtainAdminToken(unittest.TestCase):
 
     def test_trailing_slashes_on_base_stripped(self):
         args = make_token_args(URL='https://kc.example.com///')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(
             m.call_args.args[0],
@@ -446,7 +515,9 @@ class TestObtainAdminToken(unittest.TestCase):
     def test_url_with_path_prefix(self):
         # Reverse-proxied Keycloak under a sub-path.
         args = make_token_args(URL='https://example.com/auth')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(
             m.call_args.args[0],
@@ -456,7 +527,9 @@ class TestObtainAdminToken(unittest.TestCase):
     def test_missing_token_endpoint_reports_error(self):
         # A realm that announces no token endpoint is not asked for a token at all.
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             success, result = keycloak.obtain_admin_token(args, {})
         self.assertFalse(success)
         self.assertIn('token endpoint', result)
@@ -464,7 +537,9 @@ class TestObtainAdminToken(unittest.TestCase):
 
     def test_empty_token_endpoint_reports_error(self):
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             success, result = keycloak.obtain_admin_token(args, {'token_endpoint': ''})
         self.assertFalse(success)
         self.assertEqual(m.call_count, 0)
@@ -472,7 +547,9 @@ class TestObtainAdminToken(unittest.TestCase):
     def test_endpoint_from_discovery_fixture(self):
         oidc = load_fixture('openid-configuration.json')
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, oidc)
         self.assertEqual(m.call_args.args[0], oidc['token_endpoint'])
 
@@ -482,7 +559,9 @@ class TestObtainAdminToken(unittest.TestCase):
             USERNAME='admin',
             PASSWORD='linuxfabrik',
         )
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(
             m.call_args.kwargs['data'],
@@ -496,13 +575,17 @@ class TestObtainAdminToken(unittest.TestCase):
 
     def test_grant_type_is_password(self):
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(m.call_args.kwargs['data']['grant_type'], 'password')
 
     def test_credentials_flow_through(self):
         args = make_token_args(CLIENT_ID='my-client', USERNAME='svc', PASSWORD='s3cr3t')
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         body = m.call_args.kwargs['data']
         self.assertEqual(body['client_id'], 'my-client')
@@ -512,31 +595,41 @@ class TestObtainAdminToken(unittest.TestCase):
     def test_no_auth_header_sent(self):
         # The token request authenticates via the POST body, not a header.
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertNotIn('header', m.call_args.kwargs)
 
     def test_passes_insecure_true(self):
         args = make_token_args(INSECURE=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertIs(m.call_args.kwargs['insecure'], True)
 
     def test_passes_no_proxy_true(self):
         args = make_token_args(NO_PROXY=True)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertIs(m.call_args.kwargs['no_proxy'], True)
 
     def test_passes_timeout(self):
         args = make_token_args(TIMEOUT=30)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(m.call_args.kwargs['timeout'], 30)
 
     def test_full_kwargs_shape(self):
         args = make_token_args(INSECURE=True, NO_PROXY=True, TIMEOUT=12)
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(
             m.call_args.kwargs,
@@ -556,8 +649,12 @@ class TestObtainAdminToken(unittest.TestCase):
     def test_success_token_returned_verbatim(self):
         fixture = load_fixture('token-response.json')
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, fixture)):
-            success, result = keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, fixture)
+        ):
+            success, result = keycloak.obtain_admin_token(
+                args, {'token_endpoint': 'https://kc/token'}
+            )
         self.assertTrue(success)
         self.assertEqual(result, fixture)
         self.assertEqual(result['token_type'], 'Bearer')
@@ -571,7 +668,9 @@ class TestObtainAdminToken(unittest.TestCase):
             'fetch_json',
             return_value=(False, 'HTTP 401: {"error":"invalid_grant"}'),
         ):
-            success, result = keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
+            success, result = keycloak.obtain_admin_token(
+                args, {'token_endpoint': 'https://kc/token'}
+            )
         self.assertFalse(success)
         self.assertIn('invalid_grant', result)
 
@@ -580,7 +679,9 @@ class TestObtainAdminToken(unittest.TestCase):
         with mock.patch.object(
             keycloak.url, 'fetch_json', return_value=(False, 'JSONDecodeError')
         ):
-            success, result = keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
+            success, result = keycloak.obtain_admin_token(
+                args, {'token_endpoint': 'https://kc/token'}
+            )
         self.assertFalse(success)
         self.assertEqual(result, 'JSONDecodeError')
 
@@ -595,7 +696,9 @@ class TestObtainAdminToken(unittest.TestCase):
 
     def test_called_exactly_once(self):
         args = make_token_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(True, {})) as m:
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(True, {})
+        ) as m:
             keycloak.obtain_admin_token(args, {'token_endpoint': 'https://kc/token'})
         self.assertEqual(m.call_count, 1)
 
@@ -606,7 +709,6 @@ class TestObtainAdminToken(unittest.TestCase):
 
 
 class TestTypicalUsageFlow(unittest.TestCase):
-
     def test_happy_path_chains_three_calls(self):
         oidc = load_fixture('openid-configuration.json')
         token = load_fixture('token-response.json')
@@ -643,7 +745,9 @@ class TestTypicalUsageFlow(unittest.TestCase):
         # If discovery fails, the real plugin would stop via lib.base.coe; here
         # we assert the failure tuple is returned and nothing else is implied.
         discover_args = make_discover_args()
-        with mock.patch.object(keycloak.url, 'fetch_json', return_value=(False, 'unreachable')):
+        with mock.patch.object(
+            keycloak.url, 'fetch_json', return_value=(False, 'unreachable')
+        ):
             ok, result = keycloak.discover_oidc_endpoints(discover_args)
         self.assertFalse(ok)
         self.assertEqual(result, 'unreachable')

--- a/tests/lftest/unit-test/run
+++ b/tests/lftest/unit-test/run
@@ -119,7 +119,9 @@ class TestIsMariadbImage(unittest.TestCase):
 class TestMysqlStartupCommand(unittest.TestCase):
     def test_no_extra_args_uses_image_default(self):
         self.assertIsNone(
-            lftest._mysql_compatible_startup_command('docker.io/library/mariadb:11', None)
+            lftest._mysql_compatible_startup_command(
+                'docker.io/library/mariadb:11', None
+            )
         )
         self.assertIsNone(
             lftest._mysql_compatible_startup_command('docker.io/library/mysql:8', None)
@@ -127,13 +129,17 @@ class TestMysqlStartupCommand(unittest.TestCase):
 
     def test_mariadb_daemon(self):
         self.assertEqual(
-            lftest._mysql_compatible_startup_command('docker.io/library/mariadb:11', '--bar'),
+            lftest._mysql_compatible_startup_command(
+                'docker.io/library/mariadb:11', '--bar'
+            ),
             'mariadbd --bar',
         )
 
     def test_mysql_daemon(self):
         self.assertEqual(
-            lftest._mysql_compatible_startup_command('docker.io/library/mysql:8', '--foo'),
+            lftest._mysql_compatible_startup_command(
+                'docker.io/library/mysql:8', '--foo'
+            ),
             'mysqld --foo',
         )
 
@@ -164,7 +170,9 @@ class TestAttachTests(unittest.TestCase):
             check = '../x'
 
         with self.assertRaises(ValueError):
-            lftest.attach_tests(Dummy, [{'id': 'dup', 'test': 'a'}, {'id': 'dup', 'test': 'b'}])
+            lftest.attach_tests(
+                Dummy, [{'id': 'dup', 'test': 'a'}, {'id': 'dup', 'test': 'b'}]
+            )
 
 
 class TestAttachEach(unittest.TestCase):
@@ -172,7 +180,9 @@ class TestAttachEach(unittest.TestCase):
         class Dummy(unittest.TestCase):
             pass
 
-        lftest.attach_each(Dummy, ['alpha', 'beta'], lambda test, item: None, id_func=str)
+        lftest.attach_each(
+            Dummy, ['alpha', 'beta'], lambda test, item: None, id_func=str
+        )
         self.assertTrue(hasattr(Dummy, 'test_alpha'))
         self.assertTrue(hasattr(Dummy, 'test_beta'))
 
@@ -203,16 +213,22 @@ class TestRun(unittest.TestCase):
 
     def test_wrong_return_code_fails(self):
         probe = self._Probe()
-        with mock.patch.object(
-            lftest.shell, 'shell_exec', return_value=(True, ('hello world', '', 0))
-        ), self.assertRaises(AssertionError):
+        with (
+            mock.patch.object(
+                lftest.shell, 'shell_exec', return_value=(True, ('hello world', '', 0))
+            ),
+            self.assertRaises(AssertionError),
+        ):
             lftest.run(probe, '../plugin', {'test': 'stdout/case', 'assert-retc': 2})
 
     def test_missing_assert_in_fails(self):
         probe = self._Probe()
-        with mock.patch.object(
-            lftest.shell, 'shell_exec', return_value=(True, ('hello world', '', 0))
-        ), self.assertRaises(AssertionError):
+        with (
+            mock.patch.object(
+                lftest.shell, 'shell_exec', return_value=(True, ('hello world', '', 0))
+            ),
+            self.assertRaises(AssertionError),
+        ):
             lftest.run(
                 probe,
                 '../plugin',

--- a/tests/librenms/unit-test/run
+++ b/tests/librenms/unit-test/run
@@ -139,8 +139,8 @@ class LibrenmsTestBase(unittest.TestCase):
 # get_data() - request building
 # ---------------------------------------------------------------------------
 
-class TestGetDataRequest(LibrenmsTestBase):
 
+class TestGetDataRequest(LibrenmsTestBase):
     def test_returns_parsed_json_on_success(self):
         self.assertEqual(librenms.get_data(Args(), uri='/api/v0/devices'), DEVICES_OK)
 
@@ -155,12 +155,14 @@ class TestGetDataRequest(LibrenmsTestBase):
     def test_trailing_slash_on_base_url_is_stripped(self):
         class A(Args):
             URL = URL + '/'
+
         librenms.get_data(A(), uri='/api/v0/devices')
         self.assertEqual(self.sent_url(), f'{URL}/api/v0/devices')
 
     def test_multiple_trailing_slashes_on_base_stripped(self):
         class A(Args):
             URL = URL + '///'
+
         librenms.get_data(A(), uri='/api/v0/devices')
         self.assertEqual(self.sent_url(), f'{URL}/api/v0/devices')
 
@@ -180,12 +182,14 @@ class TestGetDataRequest(LibrenmsTestBase):
     def test_auth_token_value_taken_from_args(self):
         class A(Args):
             TOKEN = 'deadbeefdeadbeef'
+
         librenms.get_data(A(), uri='/x')
         self.assertEqual(self.sent_header()['X-Auth-Token'], 'deadbeefdeadbeef')
 
     def test_insecure_forwarded_true(self):
         class A(Args):
             INSECURE = True
+
         librenms.get_data(A(), uri='/x')
         self.assertTrue(self.sent_kwargs()['insecure'])
 
@@ -196,6 +200,7 @@ class TestGetDataRequest(LibrenmsTestBase):
     def test_no_proxy_forwarded_true(self):
         class A(Args):
             NO_PROXY = True
+
         librenms.get_data(A(), uri='/x')
         self.assertTrue(self.sent_kwargs()['no_proxy'])
 
@@ -206,6 +211,7 @@ class TestGetDataRequest(LibrenmsTestBase):
     def test_timeout_forwarded(self):
         class A(Args):
             TIMEOUT = 42
+
         librenms.get_data(A(), uri='/x')
         self.assertEqual(self.sent_kwargs()['timeout'], 42)
 
@@ -228,8 +234,8 @@ class TestGetDataRequest(LibrenmsTestBase):
 # get_data() - status handling
 # ---------------------------------------------------------------------------
 
-class TestGetDataStatus(LibrenmsTestBase):
 
+class TestGetDataStatus(LibrenmsTestBase):
     def test_status_ok_lowercase_returns_payload(self):
         self.fetch_json.return_value = (True, {'status': 'ok', 'foo': 1})
         self.assertEqual(librenms.get_data(Args()), {'status': 'ok', 'foo': 1})
@@ -280,6 +286,7 @@ class TestGetDataStatus(LibrenmsTestBase):
     def test_always_ok_turns_error_into_exit_zero(self):
         class A(Args):
             ALWAYS_OK = True
+
         self.fetch_json.return_value = (True, DEVICES_ERR)
         with self.assertRaises(SystemExit) as cm, redirect_stdout(io.StringIO()):
             librenms.get_data(A())
@@ -303,8 +310,8 @@ class TestGetDataStatus(LibrenmsTestBase):
 # get_data() - transport failure (coe path)
 # ---------------------------------------------------------------------------
 
-class TestGetDataTransportFailure(LibrenmsTestBase):
 
+class TestGetDataTransportFailure(LibrenmsTestBase):
     def test_fetch_failure_exits_unknown(self):
         self.fetch_json.return_value = (False, 'connection refused')
         with self.assertRaises(SystemExit) as cm, redirect_stdout(io.StringIO()):
@@ -323,6 +330,7 @@ class TestGetDataTransportFailure(LibrenmsTestBase):
         # failure exits UNKNOWN even with ALWAYS_OK=True.
         class A(Args):
             ALWAYS_OK = True
+
         self.fetch_json.return_value = (False, 'boom')
         with self.assertRaises(SystemExit) as cm, redirect_stdout(io.StringIO()):
             librenms.get_data(A())
@@ -333,8 +341,8 @@ class TestGetDataTransportFailure(LibrenmsTestBase):
 # get_prop()
 # ---------------------------------------------------------------------------
 
-class TestGetProp(unittest.TestCase):
 
+class TestGetProp(unittest.TestCase):
     # --- default mytype='str' ------------------------------------------------
 
     def test_str_existing_string_returned_unchanged(self):
@@ -404,8 +412,8 @@ class TestGetProp(unittest.TestCase):
 # get_state()
 # ---------------------------------------------------------------------------
 
-class TestGetState(unittest.TestCase):
 
+class TestGetState(unittest.TestCase):
     # --- the OK states (0=CLEAR, 2=ACKNOWLEDGED) -----------------------------
 
     def test_clear_state_is_ok_crit(self):
@@ -525,28 +533,37 @@ class TestLibrenmsContainer(unittest.TestCase):
                 wait_log_timeout=300,
             ) as app,
         ):
-            base = (
-                f'http://{app.get_container_host_ip()}:'
-                f'{app.get_exposed_port(8000)}'
-            )
+            base = f'http://{app.get_container_host_ip()}:{app.get_exposed_port(8000)}'
             # lnms must not run as root; the image's default user is root, so su
             # to the librenms user. Retry user-create + token-seed until the API
             # authenticates (handles migration / propagation timing). Poll with a
             # raw request because get_data() sys.exits on a non-ok status.
             authed = None
             for _ in range(40):
-                app.exec([
-                    'su', '-s', '/bin/sh', 'librenms', '-c',
-                    f'lnms user:add admin -p {ADMIN_PW} -r admin '
-                    '-e admin@example.com --no-interaction || true',
-                ])
-                db.exec([
-                    'mariadb', '-uroot', '-prootpw', 'librenms', '-e',
-                    'DELETE FROM api_tokens; '
-                    "INSERT INTO api_tokens (user_id, token_hash, description, disabled) "
-                    f"SELECT user_id, '{API_TOKEN}', 'test', 0 FROM users "
-                    "WHERE username = 'admin';",
-                ])
+                app.exec(
+                    [
+                        'su',
+                        '-s',
+                        '/bin/sh',
+                        'librenms',
+                        '-c',
+                        f'lnms user:add admin -p {ADMIN_PW} -r admin '
+                        '-e admin@example.com --no-interaction || true',
+                    ]
+                )
+                db.exec(
+                    [
+                        'mariadb',
+                        '-uroot',
+                        '-prootpw',
+                        'librenms',
+                        '-e',
+                        'DELETE FROM api_tokens; '
+                        'INSERT INTO api_tokens (user_id, token_hash, description, disabled) '
+                        f"SELECT user_id, '{API_TOKEN}', 'test', 0 FROM users "
+                        "WHERE username = 'admin';",
+                    ]
+                )
                 ok, res = librenms.url.fetch_json(
                     f'{base}/api/v0/devices',
                     header={'X-Auth-Token': API_TOKEN},

--- a/tests/nextcloud/unit-test/run
+++ b/tests/nextcloud/unit-test/run
@@ -78,8 +78,9 @@ def patched(which=PHP_BIN, owner=UID, shell_ret=(True, ('{}', '', 0))):
 class _Base(unittest.TestCase):
     """Shared helper to run run_occ under the three patches."""
 
-    def run_occ(self, *args, which=PHP_BIN, owner=UID,
-                shell_ret=(True, ('{}', '', 0)), **kwargs):
+    def run_occ(
+        self, *args, which=PHP_BIN, owner=UID, shell_ret=(True, ('{}', '', 0)), **kwargs
+    ):
         (which_p, owner_p, shell_p), shell_mock = patched(which, owner, shell_ret)
         with which_p, owner_p, shell_p:
             result = nextcloud.run_occ(*args, **kwargs)
@@ -111,9 +112,11 @@ class TestMissingPhp(_Base):
 
     def test_owner_not_consulted_when_no_php(self):
         # No point statting config.php if there is no interpreter to run occ.
-        with mock.patch.object(nextcloud.shutil, 'which', return_value=None), \
-             mock.patch.object(nextcloud.disk, 'get_owner') as go, \
-             mock.patch.object(nextcloud.shell, 'shell_exec') as se:
+        with (
+            mock.patch.object(nextcloud.shutil, 'which', return_value=None),
+            mock.patch.object(nextcloud.disk, 'get_owner') as go,
+            mock.patch.object(nextcloud.shell, 'shell_exec') as se,
+        ):
             nextcloud.run_occ(NC_PATH, 'status')
         go.assert_not_called()
         se.assert_not_called()
@@ -137,9 +140,13 @@ class TestCommandConstruction(_Base):
         self.shell_mock.assert_called_once()
 
     def test_owner_lookup_targets_config_php(self):
-        with mock.patch.object(nextcloud.shutil, 'which', return_value=PHP_BIN), \
-             mock.patch.object(nextcloud.disk, 'get_owner', return_value=UID) as go, \
-             mock.patch.object(nextcloud.shell, 'shell_exec', return_value=(True, ('{}', '', 0))):
+        with (
+            mock.patch.object(nextcloud.shutil, 'which', return_value=PHP_BIN),
+            mock.patch.object(nextcloud.disk, 'get_owner', return_value=UID) as go,
+            mock.patch.object(
+                nextcloud.shell, 'shell_exec', return_value=(True, ('{}', '', 0))
+            ),
+        ):
             nextcloud.run_occ(NC_PATH, 'status')
         go.assert_called_once_with(os.path.join(NC_PATH, 'config/config.php'))
 
@@ -180,7 +187,14 @@ class TestCommandConstruction(_Base):
         (cmd,), _ = self.shell_mock.call_args
         self.assertEqual(
             cmd,
-            ['sudo', '-u', '#www-data', '/usr/bin/php', '/var/www/nextcloud/occ', 'status'],
+            [
+                'sudo',
+                '-u',
+                '#www-data',
+                '/usr/bin/php',
+                '/var/www/nextcloud/occ',
+                'status',
+            ],
         )
 
     def test_shell_exec_called_once_positionally(self):
@@ -199,20 +213,23 @@ class TestJsonResponse(_Base):
     """Assert JSON parsing on the success path."""
 
     def test_parses_object(self):
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, ('{"installed": true}', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('{"installed": true}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'installed': True})
 
     def test_parses_array(self):
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, ('[1, 2, 3]', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('[1, 2, 3]', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, [1, 2, 3])
 
     def test_returns_python_types(self):
         ok, data = self.run_occ(
-            NC_PATH, 'status',
+            NC_PATH,
+            'status',
             shell_ret=(True, ('{"maintenance": false, "n": 7, "v": null}', '', 0)),
         )
         self.assertTrue(ok)
@@ -222,32 +239,37 @@ class TestJsonResponse(_Base):
 
     def test_default_format_is_json(self):
         # No _format kwarg -> JSON parsing happens.
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, ('{"a": 1}', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('{"a": 1}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'a': 1})
 
     def test_bytes_stdout_decoded_and_parsed(self):
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, (b'{"a": 1}', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, (b'{"a": 1}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'a': 1})
 
     def test_bytearray_stdout_decoded_and_parsed(self):
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, (bytearray(b'{"a": 1}'), '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, (bytearray(b'{"a": 1}'), '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'a': 1})
 
     def test_format_json_is_case_insensitive(self):
-        ok, data = self.run_occ(NC_PATH, 'status', _format='JSON',
-                                shell_ret=(True, ('{"a": 1}', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', _format='JSON', shell_ret=(True, ('{"a": 1}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'a': 1})
 
     def test_format_json_mixed_case(self):
-        ok, data = self.run_occ(NC_PATH, 'status', _format='Json',
-                                shell_ret=(True, ('{"a": 1}', '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'status', _format='Json', shell_ret=(True, ('{"a": 1}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, {'a': 1})
 
@@ -261,28 +283,30 @@ class TestJsonErrors(_Base):
     """Assert behaviour when stdout is not valid JSON."""
 
     def test_non_json_text_fails(self):
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('not json at all', '', 0)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('not json at all', '', 0))
+        )
         self.assertFalse(ok)
         self.assertIn('JSON decode error', msg)
 
     def test_error_includes_raw_stdout(self):
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('garbage-123', '', 0)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('garbage-123', '', 0))
+        )
         self.assertFalse(ok)
         self.assertIn('Raw stdout', msg)
         self.assertIn('garbage-123', msg)
 
     def test_empty_stdout_is_json_error(self):
         # rc==0 but empty stdout: json.loads('') raises -> decode error.
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('', '', 0)))
+        ok, msg = self.run_occ(NC_PATH, 'status', shell_ret=(True, ('', '', 0)))
         self.assertFalse(ok)
         self.assertIn('JSON decode error', msg)
 
     def test_truncated_json_fails(self):
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('{"installed": tr', '', 0)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('{"installed": tr', '', 0))
+        )
         self.assertFalse(ok)
         self.assertIn('JSON decode error', msg)
 
@@ -296,40 +320,52 @@ class TestTextResponse(_Base):
     """Assert raw-text mode trims and returns stdout untouched otherwise."""
 
     def test_text_format_returns_string(self):
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, ('Nextcloud is installed', '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH,
+            'status',
+            _format='text',
+            shell_ret=(True, ('Nextcloud is installed', '', 0)),
+        )
         self.assertTrue(ok)
         self.assertEqual(text, 'Nextcloud is installed')
 
     def test_text_is_stripped(self):
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, ('  hello \n', '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH, 'status', _format='text', shell_ret=(True, ('  hello \n', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(text, 'hello')
 
     def test_bytes_text_decoded_and_stripped(self):
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, (b'  hi \n', '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH, 'status', _format='text', shell_ret=(True, (b'  hi \n', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(text, 'hi')
 
     def test_bytearray_text_decoded_and_stripped(self):
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, (bytearray(b' x '), '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH,
+            'status',
+            _format='text',
+            shell_ret=(True, (bytearray(b' x '), '', 0)),
+        )
         self.assertTrue(ok)
         self.assertEqual(text, 'x')
 
     def test_text_does_not_parse_json(self):
         # In text mode JSON-looking output stays a raw string.
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, ('{"a": 1}', '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH, 'status', _format='text', shell_ret=(True, ('{"a": 1}', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(text, '{"a": 1}')
 
     def test_arbitrary_non_json_format_is_text(self):
         # Any _format other than 'json' triggers the text branch.
-        ok, text = self.run_occ(NC_PATH, 'status', _format='plain',
-                                shell_ret=(True, (' ok ', '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH, 'status', _format='plain', shell_ret=(True, (' ok ', '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(text, 'ok')
 
@@ -343,49 +379,49 @@ class TestFailurePath(_Base):
     """Assert the command-failure contract and its message composition."""
 
     def test_nonzero_rc_is_failure(self):
-        ok, _ = self.run_occ(NC_PATH, 'status',
-                             shell_ret=(True, ('', 'boom', 1)))
+        ok, _ = self.run_occ(NC_PATH, 'status', shell_ret=(True, ('', 'boom', 1)))
         self.assertFalse(ok)
 
     def test_failure_message_contains_command(self):
-        _ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('', 'boom', 1)))
+        _ok, msg = self.run_occ(NC_PATH, 'status', shell_ret=(True, ('', 'boom', 1)))
         self.assertIn('sudo -u #33 /usr/bin/php /var/www/nextcloud/occ status', msg)
 
     def test_failure_message_contains_rc(self):
-        _ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('', 'boom', 7)))
+        _ok, msg = self.run_occ(NC_PATH, 'status', shell_ret=(True, ('', 'boom', 7)))
         self.assertIn('rc=7', msg)
 
     def test_failure_prefers_stderr(self):
-        _ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('some stdout', 'the stderr', 1)))
+        _ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('some stdout', 'the stderr', 1))
+        )
         self.assertIn('the stderr', msg)
 
     def test_failure_falls_back_to_stdout_when_no_stderr(self):
         # stderr empty -> the (or-fallback) stdout is shown instead.
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('the stdout', '', 5)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('the stdout', '', 5))
+        )
         self.assertFalse(ok)
         self.assertIn('the stdout', msg)
         self.assertIn('rc=5', msg)
 
     def test_success_flag_false_is_failure(self):
         # shell_exec itself failing (success=False) is a failure even at rc 0.
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(False, ('', 'exec failed', 0)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(False, ('', 'exec failed', 0))
+        )
         self.assertFalse(ok)
         self.assertIn('exec failed', msg)
 
     def test_success_flag_false_with_rc_zero_still_fails(self):
-        ok, _ = self.run_occ(NC_PATH, 'status',
-                             shell_ret=(False, ('out', '', 0)))
+        ok, _ = self.run_occ(NC_PATH, 'status', shell_ret=(False, ('out', '', 0)))
         self.assertFalse(ok)
 
     def test_failure_short_circuits_before_json_parse(self):
         # Valid JSON in stdout must not turn an rc!=0 run into a success.
-        ok, msg = self.run_occ(NC_PATH, 'status',
-                               shell_ret=(True, ('{"a": 1}', 'err', 1)))
+        ok, msg = self.run_occ(
+            NC_PATH, 'status', shell_ret=(True, ('{"a": 1}', 'err', 1))
+        )
         self.assertFalse(ok)
         self.assertIn('err', msg)
 
@@ -401,8 +437,7 @@ class TestCapturedPayloads(_Base):
     def test_occ_status_payload(self):
         raw = load_fixture_text('status.json')
         expected = load_fixture('status.json')
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, (raw, '', 0)))
+        ok, data = self.run_occ(NC_PATH, 'status', shell_ret=(True, (raw, '', 0)))
         self.assertTrue(ok)
         self.assertEqual(data, expected)
         self.assertIs(data['installed'], True)
@@ -412,16 +447,16 @@ class TestCapturedPayloads(_Base):
     def test_occ_status_payload_as_bytes(self):
         raw = load_fixture_text('status.json').encode('utf-8')
         expected = load_fixture('status.json')
-        ok, data = self.run_occ(NC_PATH, 'status',
-                                shell_ret=(True, (raw, '', 0)))
+        ok, data = self.run_occ(NC_PATH, 'status', shell_ret=(True, (raw, '', 0)))
         self.assertTrue(ok)
         self.assertEqual(data, expected)
 
     def test_occ_user_list_payload(self):
         raw = load_fixture_text('user-list.json')
         expected = load_fixture('user-list.json')
-        ok, data = self.run_occ(NC_PATH, 'user:list --output=json',
-                                shell_ret=(True, (raw, '', 0)))
+        ok, data = self.run_occ(
+            NC_PATH, 'user:list --output=json', shell_ret=(True, (raw, '', 0))
+        )
         self.assertTrue(ok)
         self.assertEqual(data, expected)
         self.assertEqual(data['alice'], 'Alice Example')
@@ -429,8 +464,9 @@ class TestCapturedPayloads(_Base):
 
     def test_occ_status_text_mode_returns_raw(self):
         raw = load_fixture_text('status.json')
-        ok, text = self.run_occ(NC_PATH, 'status', _format='text',
-                                shell_ret=(True, (raw, '', 0)))
+        ok, text = self.run_occ(
+            NC_PATH, 'status', _format='text', shell_ret=(True, (raw, '', 0))
+        )
         self.assertTrue(ok)
         # Text mode keeps it a string (stripped), not a dict.
         self.assertIsInstance(text, str)

--- a/tests/nodebb/unit-test/run
+++ b/tests/nodebb/unit-test/run
@@ -71,6 +71,7 @@ LIST_SUCCESS = [{'cid': 1, 'name': 'General'}, {'cid': 2, 'name': 'Support'}]
 # Test args object (mimics the argparse Namespace the module expects)
 # -----------------------------------------------------------------------------
 
+
 class Args:
     """Minimal stand-in for the argparse Namespace get_data() consumes."""
 
@@ -92,6 +93,7 @@ class Args:
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
 
 def ok(payload):
     """Build the (success, body) tuple lib.url.fetch_json returns on HTTP 200."""
@@ -140,6 +142,7 @@ class NodebbTestCase(unittest.TestCase):
 # Module surface
 # -----------------------------------------------------------------------------
 
+
 class TestModuleSurface(NodebbTestCase):
     def test_public_function_exists(self):
         self.assertTrue(callable(getattr(nodebb, 'get_data', None)))
@@ -160,6 +163,7 @@ class TestModuleSurface(NodebbTestCase):
 # -----------------------------------------------------------------------------
 # get_data - success path (coe returns result[1] directly)
 # -----------------------------------------------------------------------------
+
 
 class TestGetDataSuccess(NodebbTestCase):
     def test_returns_payload_dict_directly(self):
@@ -194,6 +198,7 @@ class TestGetDataSuccess(NodebbTestCase):
 # -----------------------------------------------------------------------------
 # get_data - request shape (URL, header, kwargs)
 # -----------------------------------------------------------------------------
+
 
 class TestGetDataRequestShape(NodebbTestCase):
     def test_url_concatenates_base_and_uri(self):
@@ -274,9 +279,15 @@ class TestGetDataRequestShape(NodebbTestCase):
         # change to fetch_json defaults cannot silently alter requests.
         m = self.patch_fetch(ok(POSTS_SUCCESS))
         nodebb.get_data(Args(), uri='/api')
-        self.assertEqual(set(m.call_args.kwargs), {
-            'header', 'insecure', 'no_proxy', 'timeout',
-        })
+        self.assertEqual(
+            set(m.call_args.kwargs),
+            {
+                'header',
+                'insecure',
+                'no_proxy',
+                'timeout',
+            },
+        )
 
     def test_url_passed_positionally(self):
         # The URL is the single positional argument to fetch_json.
@@ -288,6 +299,7 @@ class TestGetDataRequestShape(NodebbTestCase):
 # -----------------------------------------------------------------------------
 # get_data - failure path (coe prints + sys.exit)
 # -----------------------------------------------------------------------------
+
 
 class TestGetDataFailure(NodebbTestCase):
     def test_transport_failure_exits_unknown(self):
@@ -344,6 +356,7 @@ class TestGetDataFailure(NodebbTestCase):
 # -----------------------------------------------------------------------------
 # get_data - integration of request shape with the failure path
 # -----------------------------------------------------------------------------
+
 
 class TestGetDataFailureStillBuildsRequest(NodebbTestCase):
     def test_request_is_built_before_failure(self):

--- a/tests/openmetrics/unit-test/run
+++ b/tests/openmetrics/unit-test/run
@@ -92,7 +92,6 @@ nextcloud_active_users{time="Last day"} 3
 
 
 class TestParseDialect(unittest.TestCase):
-
     def test_autodetects_openmetrics_by_eof_marker(self):
         success, samples = openmetrics.parse(OM_PAYLOAD)
         self.assertTrue(success)
@@ -121,15 +120,18 @@ class TestParseDialect(unittest.TestCase):
         self.assertAlmostEqual(samples[0]['timestamp'], 123.123)
 
     def test_payload_not_ending_in_the_eof_marker_is_rejected(self):
-        success, result = openmetrics.parse('# TYPE a gauge\n# EOF\na 1\n',
-                                            dialect='openmetrics')
+        success, result = openmetrics.parse(
+            '# TYPE a gauge\n# EOF\na 1\n', dialect='openmetrics'
+        )
         self.assertFalse(success)
         self.assertIn('does not end with # EOF', result)
 
     def test_data_behind_an_interior_eof_marker_is_rejected(self):
         # The payload does end in the marker, so it takes a second one to reach
         # the case of data behind it.
-        success, result = openmetrics.parse('a 1\n# EOF\nb 2\n# EOF\n', dialect='openmetrics')
+        success, result = openmetrics.parse(
+            'a 1\n# EOF\nb 2\n# EOF\n', dialect='openmetrics'
+        )
         self.assertFalse(success)
         self.assertIn('unexpected data after # EOF', result)
 
@@ -190,7 +192,6 @@ class TestParseLineBreaks(unittest.TestCase):
 
 
 class TestParseMetadata(unittest.TestCase):
-
     def _first(self, payload, name):
         success, samples = openmetrics.parse(payload)
         self.assertTrue(success)
@@ -210,10 +211,14 @@ class TestParseMetadata(unittest.TestCase):
     def test_sample_inherits_metadata_of_its_family(self):
         # `# TYPE rpc_requests counter` describes the family, the sample is
         # named rpc_requests_total.
-        self.assertEqual(self._first(OM_PAYLOAD, 'rpc_requests_total')['type'], 'counter')
+        self.assertEqual(
+            self._first(OM_PAYLOAD, 'rpc_requests_total')['type'], 'counter'
+        )
 
     def test_created_sample_inherits_metadata_of_its_family(self):
-        self.assertEqual(self._first(OM_PAYLOAD, 'rpc_requests_created')['type'], 'counter')
+        self.assertEqual(
+            self._first(OM_PAYLOAD, 'rpc_requests_created')['type'], 'counter'
+        )
 
     def test_bucket_sample_inherits_metadata_of_its_family(self):
         sample = self._first(OM_PAYLOAD, 'request_duration_seconds_bucket')
@@ -229,14 +234,18 @@ class TestParseMetadata(unittest.TestCase):
     def test_metadata_does_not_leak_into_a_foreign_family(self):
         # A family switch without new metadata must not inherit the previous
         # type, which is exactly what the reference parser gets wrong.
-        payload = '# TYPE first_metric histogram\nfirst_metric 1\nwind_speed{a="2"} 12345\n'
+        payload = (
+            '# TYPE first_metric histogram\nfirst_metric 1\nwind_speed{a="2"} 12345\n'
+        )
         success, samples = openmetrics.parse(payload, dialect='prometheus')
         self.assertTrue(success)
         self.assertEqual(samples[1]['type'], 'unknown')
 
     def test_empty_help_reads_as_no_help_at_all(self):
         # The specification has an empty text mean the line is not there.
-        success, samples = openmetrics.parse('# HELP nohelp1 \nnohelp1 1\n', dialect='prometheus')
+        success, samples = openmetrics.parse(
+            '# HELP nohelp1 \nnohelp1 1\n', dialect='prometheus'
+        )
         self.assertTrue(success)
         self.assertIsNone(samples[0]['help'])
 
@@ -262,12 +271,16 @@ class TestParseMetadata(unittest.TestCase):
         # Grafana and MinIO both declare counters whose name lacks the _total
         # suffix the specification asks for. The name is reported as served, so
         # that selecting a metric works off what the endpoint actually sends.
-        payload = '# TYPE minio_audit_total_messages counter\nminio_audit_total_messages 5\n'
+        payload = (
+            '# TYPE minio_audit_total_messages counter\nminio_audit_total_messages 5\n'
+        )
         success, samples = openmetrics.parse(payload, dialect='prometheus')
         self.assertTrue(success, msg=samples)
         self.assertEqual(samples[0]['name'], 'minio_audit_total_messages')
         self.assertEqual(samples[0]['type'], 'counter')
-        self.assertEqual(openmetrics.get_value(samples, 'minio_audit_total_messages'), 5.0)
+        self.assertEqual(
+            openmetrics.get_value(samples, 'minio_audit_total_messages'), 5.0
+        )
 
     def test_help_on_a_sample_name_does_not_hide_the_family_type(self):
         payload = '# TYPE foo counter\n# HELP foo_total Total of foo.\nfoo_total 1\n'
@@ -279,8 +292,10 @@ class TestParseMetadata(unittest.TestCase):
     def test_a_sample_declaring_its_own_type_is_its_own_family(self):
         # `a_total` says what it is, so it is not the `_total` of `a` and `# HELP
         # a` does not describe it.
-        payload = ('# TYPE a counter\n# HELP a Help of family a.\n# TYPE a_total gauge\n'
-                   'a_total 1\n# EOF\n')
+        payload = (
+            '# TYPE a counter\n# HELP a Help of family a.\n# TYPE a_total gauge\n'
+            'a_total 1\n# EOF\n'
+        )
         success, samples = openmetrics.parse(payload)
         self.assertTrue(success, msg=samples)
         self.assertEqual(samples[0]['type'], 'gauge')
@@ -327,13 +342,16 @@ class TestParseMetadata(unittest.TestCase):
     def test_metadata_name_must_be_consumed_whole(self):
         # `a-b` is not a name the legacy charset covers, so reading the `a` that
         # matched would attach this line to a different metric than it names.
-        success, result = openmetrics.parse('# TYPE a counter\n# HELP a-b some help\na_total 1\n'
-                                            '# EOF\n')
+        success, result = openmetrics.parse(
+            '# TYPE a counter\n# HELP a-b some help\na_total 1\n# EOF\n'
+        )
         self.assertFalse(success)
         self.assertIn('expected a metric name', result)
 
     def test_openmetrics_only_type_is_rejected_in_prometheus(self):
-        success, result = openmetrics.parse('# TYPE a info\na 1\n', dialect='prometheus')
+        success, result = openmetrics.parse(
+            '# TYPE a info\na 1\n', dialect='prometheus'
+        )
         self.assertFalse(success)
         self.assertIn('invalid metric type', result)
 
@@ -350,8 +368,9 @@ class TestParseMetadata(unittest.TestCase):
         self.assertIn('is not a suffix of metric', result)
 
     def test_unit_without_an_underscore_is_not_a_suffix(self):
-        success, result = openmetrics.parse('# UNIT metricsuffix suffix\nmetricsuffix 1\n'
-                                            '# EOF\n')
+        success, result = openmetrics.parse(
+            '# UNIT metricsuffix suffix\nmetricsuffix 1\n# EOF\n'
+        )
         self.assertFalse(success)
         self.assertIn('is not a suffix of metric', result)
 
@@ -363,14 +382,17 @@ class TestParseMetadata(unittest.TestCase):
         self.assertIsNone(samples[0]['unit'])
 
     def test_empty_unit_does_not_erase_a_filled_one(self):
-        success, samples = openmetrics.parse('# UNIT a_seconds seconds\n# UNIT a_seconds \n'
-                                             'a_seconds 1\n# EOF\n')
+        success, samples = openmetrics.parse(
+            '# UNIT a_seconds seconds\n# UNIT a_seconds \na_seconds 1\n# EOF\n'
+        )
         self.assertTrue(success, msg=samples)
         self.assertEqual(samples[0]['unit'], 'seconds')
 
     def test_unit_is_a_comment_in_prometheus(self):
         # The Prometheus format has no units.
-        success, samples = openmetrics.parse('# UNIT a seconds\na 1\n', dialect='prometheus')
+        success, samples = openmetrics.parse(
+            '# UNIT a seconds\na 1\n', dialect='prometheus'
+        )
         self.assertTrue(success, msg=samples)
         self.assertIsNone(samples[0]['unit'])
 
@@ -387,12 +409,16 @@ class TestParseMetadata(unittest.TestCase):
     def test_untyped_is_reported_as_unknown(self):
         # The Prometheus spelling of the same thing, so that a caller compares
         # against one name instead of two.
-        success, samples = openmetrics.parse('# TYPE a untyped\na 1\n', dialect='prometheus')
+        success, samples = openmetrics.parse(
+            '# TYPE a untyped\na 1\n', dialect='prometheus'
+        )
         self.assertTrue(success)
         self.assertEqual(samples[0]['type'], 'unknown')
 
     def test_double_space_behind_the_keyword(self):
-        success, samples = openmetrics.parse('# TYPE  a  gauge\na 1\n', dialect='prometheus')
+        success, samples = openmetrics.parse(
+            '# TYPE  a  gauge\na 1\n', dialect='prometheus'
+        )
         self.assertTrue(success, msg=samples)
         self.assertEqual(samples[0]['type'], 'gauge')
 
@@ -412,7 +438,6 @@ class TestParseMetadata(unittest.TestCase):
 
 
 class TestParseLabels(unittest.TestCase):
-
     def _labels(self, payload):
         success, samples = openmetrics.parse(payload, dialect='prometheus')
         self.assertTrue(success, msg=samples)
@@ -431,14 +456,17 @@ class TestParseLabels(unittest.TestCase):
         self.assertEqual(self._labels('metric{a="1",} 1\n'), {'a': '1'})
 
     def test_prometheus_tolerates_whitespace_around_labels(self):
-        self.assertEqual(self._labels('metric { a = "1" , b = "2" } 1\n'), {'a': '1', 'b': '2'})
+        self.assertEqual(
+            self._labels('metric { a = "1" , b = "2" } 1\n'), {'a': '1', 'b': '2'}
+        )
 
     def test_label_name_may_start_with_underscore(self):
         self.assertEqual(self._labels('metric{_a="1"} 1\n'), {'_a': '1'})
 
     def test_colon_in_metric_name(self):
-        success, samples = openmetrics.parse('some:aggregate:rate5m{a_b="c"} 1\n',
-                                             dialect='prometheus')
+        success, samples = openmetrics.parse(
+            'some:aggregate:rate5m{a_b="c"} 1\n', dialect='prometheus'
+        )
         self.assertTrue(success)
         self.assertEqual(samples[0]['name'], 'some:aggregate:rate5m')
 
@@ -466,7 +494,9 @@ class TestParseLabels(unittest.TestCase):
         # Keeping either one would be a guess, so the sample goes on the floor.
         # The payload around it is read: the line is well-formed, so the reader
         # still knows where it is, and every other sample states the truth.
-        success, samples = openmetrics.parse('good_a 1\nmetric{a="1",a="2"} 1\ngood_c 3\n# EOF\n')
+        success, samples = openmetrics.parse(
+            'good_a 1\nmetric{a="1",a="2"} 1\ngood_c 3\n# EOF\n'
+        )
         self.assertTrue(success, msg=samples)
         self.assertEqual([s['name'] for s in samples], ['good_a', 'good_c'])
 
@@ -488,13 +518,16 @@ class TestParseLabels(unittest.TestCase):
     def test_duplicate_label_does_not_swallow_a_syntax_error_behind_it(self):
         # A line the grammar cannot take apart still fails the payload: past it
         # the reader no longer knows where it is.
-        success, result = openmetrics.parse('metric{a="1",a="2"} notanumber\n',
-                                            dialect='prometheus')
+        success, result = openmetrics.parse(
+            'metric{a="1",a="2"} notanumber\n', dialect='prometheus'
+        )
         self.assertFalse(success)
         self.assertIn('not a number', result)
 
     def test_duplicate_label_does_not_swallow_a_broken_label_set_behind_it(self):
-        success, result = openmetrics.parse('metric{a="1",a="2",b} 1\n', dialect='prometheus')
+        success, result = openmetrics.parse(
+            'metric{a="1",a="2",b} 1\n', dialect='prometheus'
+        )
         self.assertFalse(success)
         self.assertIn('expected "="', result)
 
@@ -523,7 +556,9 @@ class TestParseLabels(unittest.TestCase):
     def test_missing_comma_behind_a_quoted_name_is_rejected(self):
         # A quoted string is only the metric name where a comma or the end of the label set
         # follows it. Without one it is read as a label name, which then lacks its value.
-        success, result = openmetrics.parse('{"my.metric"a="1"} 1\n', dialect='prometheus')
+        success, result = openmetrics.parse(
+            '{"my.metric"a="1"} 1\n', dialect='prometheus'
+        )
         self.assertFalse(success)
         self.assertIn('expected "="', result)
 
@@ -545,9 +580,10 @@ class TestParseLabels(unittest.TestCase):
 
 
 class TestParseEscaping(unittest.TestCase):
-
     def _value(self, raw):
-        success, samples = openmetrics.parse(f'metric{{a="{raw}"}} 1\n', dialect='prometheus')
+        success, samples = openmetrics.parse(
+            f'metric{{a="{raw}"}} 1\n', dialect='prometheus'
+        )
         self.assertTrue(success, msg=samples)
         return samples[0]['labels']['a']
 
@@ -658,7 +694,6 @@ class TestParseEscaping(unittest.TestCase):
 
 
 class TestParseValue(unittest.TestCase):
-
     def _value(self, raw):
         success, samples = openmetrics.parse(f'metric {raw}\n', dialect='prometheus')
         self.assertTrue(success, msg=samples)
@@ -714,14 +749,15 @@ class TestParseValue(unittest.TestCase):
 
 
 class TestParseTimestamp(unittest.TestCase):
-
     def test_no_timestamp_is_none(self):
         success, samples = openmetrics.parse('metric 1\n', dialect='prometheus')
         self.assertTrue(success)
         self.assertIsNone(samples[0]['timestamp'])
 
     def test_openmetrics_timestamp_is_seconds(self):
-        success, samples = openmetrics.parse('metric 33 123.123\n# EOF\n', dialect='openmetrics')
+        success, samples = openmetrics.parse(
+            'metric 33 123.123\n# EOF\n', dialect='openmetrics'
+        )
         self.assertTrue(success)
         self.assertAlmostEqual(samples[0]['timestamp'], 123.123)
 
@@ -742,8 +778,9 @@ class TestParseTimestamp(unittest.TestCase):
     def test_prometheus_timestamp_out_of_int64_range_is_rejected(self):
         # Python carries the number, the format does not, so it is a digit run
         # that merely looks like a point in time.
-        success, result = openmetrics.parse('foo 1 99999999999999999999999\n',
-                                            dialect='prometheus')
+        success, result = openmetrics.parse(
+            'foo 1 99999999999999999999999\n', dialect='prometheus'
+        )
         self.assertFalse(success)
         self.assertIn('out of range', result)
 
@@ -763,7 +800,9 @@ class TestParseTimestamp(unittest.TestCase):
         self.assertIn('not a number', result)
 
     def test_nan_timestamp_is_rejected(self):
-        success, result = openmetrics.parse('metric 1 NaN\n# EOF\n', dialect='openmetrics')
+        success, result = openmetrics.parse(
+            'metric 1 NaN\n# EOF\n', dialect='openmetrics'
+        )
         self.assertFalse(success)
         self.assertIn('invalid timestamp', result)
 
@@ -773,18 +812,21 @@ class TestParseTimestamp(unittest.TestCase):
         self.assertIn('not a number', result)
 
     def test_infinite_timestamp_is_rejected(self):
-        success, result = openmetrics.parse('metric 1 Inf\n# EOF\n', dialect='openmetrics')
+        success, result = openmetrics.parse(
+            'metric 1 Inf\n# EOF\n', dialect='openmetrics'
+        )
         self.assertFalse(success)
         self.assertIn('invalid timestamp', result)
 
     def test_second_timestamp_is_rejected(self):
-        success, result = openmetrics.parse('metric 1 1 1\n# EOF\n', dialect='openmetrics')
+        success, result = openmetrics.parse(
+            'metric 1 1 1\n# EOF\n', dialect='openmetrics'
+        )
         self.assertFalse(success)
         self.assertIn('expected nothing behind the timestamp', result)
 
 
 class TestParseExemplar(unittest.TestCase):
-
     def test_exemplar_is_dropped(self):
         payload = 'foo_total 17.0 1520879607.789 # {id="counter-test"} 5\n# EOF\n'
         success, samples = openmetrics.parse(payload)
@@ -819,32 +861,36 @@ class TestParseExemplar(unittest.TestCase):
 
 
 class TestGetSamples(unittest.TestCase):
-
     def setUp(self):
         success, self.samples = openmetrics.parse(NEXTCLOUD_PAYLOAD)
         self.assertTrue(success)
 
     def test_by_name(self):
-        self.assertEqual(len(openmetrics.get_samples(self.samples, 'nextcloud_app_enabled')), 3)
+        self.assertEqual(
+            len(openmetrics.get_samples(self.samples, 'nextcloud_app_enabled')), 3
+        )
 
     def test_by_name_and_label(self):
-        found = openmetrics.get_samples(self.samples, 'nextcloud_app_enabled',
-                                        labels={'app_id': 'spreed'})
+        found = openmetrics.get_samples(
+            self.samples, 'nextcloud_app_enabled', labels={'app_id': 'spreed'}
+        )
         self.assertEqual(len(found), 1)
         self.assertEqual(found[0]['value'], 1.0)
 
     def test_labels_match_as_a_subset(self):
         # app_enabled also carries a version label, which the caller need not know.
-        found = openmetrics.get_samples(self.samples, 'nextcloud_app_enabled',
-                                        labels={'app_id': 'files'})
+        found = openmetrics.get_samples(
+            self.samples, 'nextcloud_app_enabled', labels={'app_id': 'files'}
+        )
         self.assertEqual(len(found), 1)
 
     def test_absent_metric_is_an_empty_list(self):
         self.assertEqual(openmetrics.get_samples(self.samples, 'nope'), [])
 
     def test_absent_label_is_an_empty_list(self):
-        found = openmetrics.get_samples(self.samples, 'nextcloud_app_enabled',
-                                        labels={'app_id': 'nope'})
+        found = openmetrics.get_samples(
+            self.samples, 'nextcloud_app_enabled', labels={'app_id': 'nope'}
+        )
         self.assertEqual(found, [])
 
     def test_name_matches_exactly_not_by_prefix(self):
@@ -852,24 +898,27 @@ class TestGetSamples(unittest.TestCase):
 
     def test_order_is_kept(self):
         found = openmetrics.get_samples(self.samples, 'nextcloud_app_enabled')
-        self.assertEqual([sample['labels']['app_id'] for sample in found],
-                         ['files', 'spreed', 'encryption'])
+        self.assertEqual(
+            [sample['labels']['app_id'] for sample in found],
+            ['files', 'spreed', 'encryption'],
+        )
 
 
 class TestGetValue(unittest.TestCase):
-
     def setUp(self):
         success, self.samples = openmetrics.parse(NEXTCLOUD_PAYLOAD)
         self.assertTrue(success)
 
     def test_enabled_app(self):
-        value = openmetrics.get_value(self.samples, 'nextcloud_app_enabled',
-                                      labels={'app_id': 'spreed'})
+        value = openmetrics.get_value(
+            self.samples, 'nextcloud_app_enabled', labels={'app_id': 'spreed'}
+        )
         self.assertEqual(value, 1.0)
 
     def test_disabled_app(self):
-        value = openmetrics.get_value(self.samples, 'nextcloud_app_enabled',
-                                      labels={'app_id': 'encryption'})
+        value = openmetrics.get_value(
+            self.samples, 'nextcloud_app_enabled', labels={'app_id': 'encryption'}
+        )
         self.assertEqual(value, 0.0)
 
     def test_absent_returns_default(self):
@@ -893,7 +942,9 @@ class TestGetValue(unittest.TestCase):
         # An info may only carry the value 1 per the specification, and its name
         # should end in _info. Nextcloud sends neither. Reading it is the point:
         # a plugin that refused this payload would report nothing at all.
-        self.assertEqual(openmetrics.get_value(self.samples, 'nextcloud_maintenance'), 0.0)
+        self.assertEqual(
+            openmetrics.get_value(self.samples, 'nextcloud_maintenance'), 0.0
+        )
 
     def test_timestamp_of_a_live_sample(self):
         found = openmetrics.get_samples(self.samples, 'nextcloud_instance_info')
@@ -902,11 +953,15 @@ class TestGetValue(unittest.TestCase):
     def test_a_disabled_app_is_not_the_same_as_an_absent_one(self):
         # Both are falsy, which is why the default has to be distinguishable.
         self.assertEqual(
-            openmetrics.get_value(self.samples, 'nextcloud_app_enabled',
-                                  labels={'app_id': 'encryption'}), 0.0
+            openmetrics.get_value(
+                self.samples, 'nextcloud_app_enabled', labels={'app_id': 'encryption'}
+            ),
+            0.0,
         )
         self.assertIsNone(
-            openmetrics.get_value(self.samples, 'nextcloud_app_enabled', labels={'app_id': 'mail'})
+            openmetrics.get_value(
+                self.samples, 'nextcloud_app_enabled', labels={'app_id': 'mail'}
+            )
         )
 
 

--- a/tests/powershell/unit-test/run
+++ b/tests/powershell/unit-test/run
@@ -35,6 +35,7 @@ import lib.powershell as powershell
 # Helpers / fakes
 # ---------------------------------------------------------------------------
 
+
 class FakeCompletedProcess:
     """Minimal stand-in for subprocess.CompletedProcess.
 
@@ -56,7 +57,8 @@ def patch_run(**kwargs):
     assert on how subprocess.run was invoked.
     """
     return mock.patch.object(
-        powershell.subprocess, 'run',
+        powershell.subprocess,
+        'run',
         return_value=FakeCompletedProcess(**kwargs),
     )
 
@@ -80,6 +82,7 @@ SAMPLE_STDERR = (
 # ---------------------------------------------------------------------------
 # run_ps() - happy path / return shape
 # ---------------------------------------------------------------------------
+
 
 class TestRunPsReturnShape(unittest.TestCase):
     def test_returns_dict(self):
@@ -109,6 +112,7 @@ class TestRunPsReturnShape(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # run_ps() - stream decoding
 # ---------------------------------------------------------------------------
+
 
 class TestRunPsDecoding(unittest.TestCase):
     def test_stdout_decoded_to_text(self):
@@ -153,9 +157,12 @@ class TestRunPsDecoding(unittest.TestCase):
     def test_decoding_delegates_to_txt_to_text(self):
         # Prove run_ps uses txt.to_text rather than a bare .decode(), so the
         # library's decoding policy (UTF-8 with Latin-1 fallback) applies.
-        with patch_run(stdout=b'X', stderr=b'Y'), mock.patch.object(
-            powershell.txt, 'to_text', side_effect=lambda _, **kw: 'DECODED'
-        ) as m:
+        with (
+            patch_run(stdout=b'X', stderr=b'Y'),
+            mock.patch.object(
+                powershell.txt, 'to_text', side_effect=lambda _, **kw: 'DECODED'
+            ) as m,
+        ):
             result = powershell.run_ps('x')
         self.assertEqual(result['stdout'], 'DECODED')
         self.assertEqual(result['stderr'], 'DECODED')
@@ -164,9 +171,12 @@ class TestRunPsDecoding(unittest.TestCase):
     def test_decoding_uses_strict_or_latin1(self):
         # run_ps must ask to_text for the Latin-1 fallback policy, not the default
         # surrogateescape, so non-UTF-8 output survives the later stdout re-encode.
-        with patch_run(stdout=b'X'), mock.patch.object(
-            powershell.txt, 'to_text', side_effect=lambda _, **kw: 'DECODED'
-        ) as m:
+        with (
+            patch_run(stdout=b'X'),
+            mock.patch.object(
+                powershell.txt, 'to_text', side_effect=lambda _, **kw: 'DECODED'
+            ) as m,
+        ):
             powershell.run_ps('x')
         self.assertEqual(m.call_args.kwargs.get('errors'), 'strict_or_latin1')
 
@@ -174,6 +184,7 @@ class TestRunPsDecoding(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # run_ps() - non-zero return codes
 # ---------------------------------------------------------------------------
+
 
 class TestRunPsNonZero(unittest.TestCase):
     def test_nonzero_returncode_passed_through(self):
@@ -197,10 +208,12 @@ class TestRunPsNonZero(unittest.TestCase):
 # run_ps() - subprocess invocation contract
 # ---------------------------------------------------------------------------
 
+
 class TestRunPsInvocation(unittest.TestCase):
     def test_invokes_powershell_with_command_flag(self):
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps('Get-Process')
@@ -210,7 +223,8 @@ class TestRunPsInvocation(unittest.TestCase):
     def test_passes_command_verbatim(self):
         cmd = 'Get-CimInstance Win32_OperatingSystem | Select-Object Caption'
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps(cmd)
@@ -218,7 +232,8 @@ class TestRunPsInvocation(unittest.TestCase):
 
     def test_capture_output_is_enabled(self):
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps('x')
@@ -226,7 +241,8 @@ class TestRunPsInvocation(unittest.TestCase):
 
     def test_called_exactly_once(self):
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps('x')
@@ -235,7 +251,8 @@ class TestRunPsInvocation(unittest.TestCase):
     def test_does_not_pass_shell_true(self):
         # The list-arg form must not run through a shell.
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps('x')
@@ -243,7 +260,8 @@ class TestRunPsInvocation(unittest.TestCase):
 
     def test_empty_command_still_invokes_powershell(self):
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps('')
@@ -253,7 +271,8 @@ class TestRunPsInvocation(unittest.TestCase):
         # run_ps does no splitting/quoting; the whole string is one argv item.
         cmd = 'Write-Output "a b" | Sort-Object'
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             return_value=FakeCompletedProcess(),
         ) as m:
             powershell.run_ps(cmd)
@@ -264,11 +283,13 @@ class TestRunPsInvocation(unittest.TestCase):
 # run_ps() - exception handling
 # ---------------------------------------------------------------------------
 
+
 class TestRunPsExceptions(unittest.TestCase):
     def test_filenotfound_yields_retc_1(self):
         # powershell not on PATH (e.g. running on Linux) -> FileNotFoundError.
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             side_effect=FileNotFoundError(2, 'No such file or directory', 'powershell'),
         ):
             result = powershell.run_ps('Get-Process')
@@ -278,7 +299,9 @@ class TestRunPsExceptions(unittest.TestCase):
 
     def test_oserror_is_caught(self):
         with mock.patch.object(
-            powershell.subprocess, 'run', side_effect=OSError('boom'),
+            powershell.subprocess,
+            'run',
+            side_effect=OSError('boom'),
         ):
             result = powershell.run_ps('x')
         self.assertEqual(result['retc'], 1)
@@ -287,7 +310,9 @@ class TestRunPsExceptions(unittest.TestCase):
 
     def test_generic_exception_is_caught(self):
         with mock.patch.object(
-            powershell.subprocess, 'run', side_effect=RuntimeError('weird'),
+            powershell.subprocess,
+            'run',
+            side_effect=RuntimeError('weird'),
         ):
             result = powershell.run_ps('x')
         self.assertEqual(result['retc'], 1)
@@ -297,7 +322,8 @@ class TestRunPsExceptions(unittest.TestCase):
         # No timeout is applied by run_ps, but if the layer below raises one
         # (e.g. via a wrapping mock), it must still degrade to retc=1.
         with mock.patch.object(
-            powershell.subprocess, 'run',
+            powershell.subprocess,
+            'run',
             side_effect=subprocess.TimeoutExpired(cmd='powershell', timeout=5),
         ):
             result = powershell.run_ps('Start-Sleep 999')
@@ -307,7 +333,9 @@ class TestRunPsExceptions(unittest.TestCase):
 
     def test_exception_result_has_documented_keys(self):
         with mock.patch.object(
-            powershell.subprocess, 'run', side_effect=ValueError('x'),
+            powershell.subprocess,
+            'run',
+            side_effect=ValueError('x'),
         ):
             result = powershell.run_ps('x')
         self.assertEqual(set(result.keys()), {'retc', 'stdout', 'stderr'})
@@ -315,11 +343,18 @@ class TestRunPsExceptions(unittest.TestCase):
     def test_exception_message_built_via_exception2text(self):
         # Prove the error string comes from txt.exception2text, not str(e).
         sentinel = ValueError('original')
-        with mock.patch.object(
-            powershell.subprocess, 'run', side_effect=sentinel,
-        ), mock.patch.object(
-            powershell.txt, 'exception2text', return_value='SANITIZED',
-        ) as m:
+        with (
+            mock.patch.object(
+                powershell.subprocess,
+                'run',
+                side_effect=sentinel,
+            ),
+            mock.patch.object(
+                powershell.txt,
+                'exception2text',
+                return_value='SANITIZED',
+            ) as m,
+        ):
             result = powershell.run_ps('x')
         self.assertEqual(result['stderr'], 'SANITIZED')
         m.assert_called_once_with(sentinel)
@@ -327,9 +362,18 @@ class TestRunPsExceptions(unittest.TestCase):
     def test_decoding_failure_is_caught(self):
         # If to_text itself raises while decoding stdout, the broad except
         # turns it into a retc=1 result rather than propagating.
-        with patch_run(stdout=b'\xff\xfe'), mock.patch.object(
-            powershell.txt, 'to_text', side_effect=UnicodeDecodeError(
-                'utf-8', b'\xff', 0, 1, 'invalid start byte',
+        with (
+            patch_run(stdout=b'\xff\xfe'),
+            mock.patch.object(
+                powershell.txt,
+                'to_text',
+                side_effect=UnicodeDecodeError(
+                    'utf-8',
+                    b'\xff',
+                    0,
+                    1,
+                    'invalid start byte',
+                ),
             ),
         ):
             result = powershell.run_ps('x')

--- a/tests/psutil/unit-test/run
+++ b/tests/psutil/unit-test/run
@@ -24,6 +24,7 @@ sys.path.insert(0, '..')
 
 try:
     import lib.psutil as lib_psutil
+
     HAVE_PSUTIL = True
 except SystemExit:
     # lib.psutil sys.exit()s with STATE_UNKNOWN when psutil is missing.

--- a/tests/qts/unit-test/run
+++ b/tests/qts/unit-test/run
@@ -172,7 +172,9 @@ class TestGetAuthSidRequestBuilding(unittest.TestCase):
         import base64
 
         captured, _ = self._call(password='')
-        self.assertEqual(captured['kw']['data']['pwd'], base64.b64encode(b'').decode('ascii'))
+        self.assertEqual(
+            captured['kw']['data']['pwd'], base64.b64encode(b'').decode('ascii')
+        )
 
     def test_body_has_exactly_user_and_pwd(self):
         captured, _ = self._call()
@@ -215,7 +217,9 @@ class TestGetAuthSidRequestBuilding(unittest.TestCase):
 
     def test_url_passed_positionally(self):
         # The URL is the sole positional argument to the delegate.
-        recorder = mock.Mock(return_value=(True, xml_response(auth_passed='1', auth_sid='S')))
+        recorder = mock.Mock(
+            return_value=(True, xml_response(auth_passed='1', auth_sid='S'))
+        )
         with mock.patch.object(qts.url, 'fetch', recorder):
             qts.get_auth_sid(FakeArgs(url='https://h'))
         args, _ = recorder.call_args

--- a/tests/redfish/unit-test/run
+++ b/tests/redfish/unit-test/run
@@ -194,7 +194,9 @@ class TestGetAuthHeader(unittest.TestCase):
         self.assertEqual(redfish.get_auth_header(_args(PASSWORD='')), {})
 
     @mock.patch.object(redfish, 'url')
-    def test_uncached_session_returns_token_header_without_probing_timeout(self, url_mock):
+    def test_uncached_session_returns_token_header_without_probing_timeout(
+        self, url_mock
+    ):
         # cache_expire=0 (default): create a session, return its token header, and
         # do NOT probe the SessionService (there is no lifetime to bound).
         url_mock.fetch_json.side_effect = [SESSION_CREATED]
@@ -220,7 +222,10 @@ class TestGetAuthHeader(unittest.TestCase):
     ):
         cache_mock.get.return_value = False  # cache miss
         time_mock.now.return_value = 1000
-        url_mock.fetch_json.side_effect = [SESSION_CREATED, (True, {'SessionTimeout': 300})]
+        url_mock.fetch_json.side_effect = [
+            SESSION_CREATED,
+            (True, {'SessionTimeout': 300}),
+        ]
         header = redfish.get_auth_header(_args(TIMEOUT=8), cache_expire=3600)
         self.assertEqual(header, {'X-Auth-Token': 'new-token'})
         # min(3600, 300 - 8) = 292, cached until now + 292
@@ -231,10 +236,15 @@ class TestGetAuthHeader(unittest.TestCase):
     @mock.patch.object(redfish, 'time')
     @mock.patch.object(redfish, 'cache')
     @mock.patch.object(redfish, 'url')
-    def test_cache_expire_caps_a_large_session_timeout(self, url_mock, cache_mock, time_mock):
+    def test_cache_expire_caps_a_large_session_timeout(
+        self, url_mock, cache_mock, time_mock
+    ):
         cache_mock.get.return_value = False
         time_mock.now.return_value = 1000
-        url_mock.fetch_json.side_effect = [SESSION_CREATED, (True, {'SessionTimeout': 86400})]
+        url_mock.fetch_json.side_effect = [
+            SESSION_CREATED,
+            (True, {'SessionTimeout': 86400}),
+        ]
         redfish.get_auth_header(_args(TIMEOUT=8), cache_expire=60)
         # min(60, 86400 - 8) = 60
         self.assertEqual(cache_mock.set.call_args[0][2], 1000 + 60)
@@ -245,7 +255,10 @@ class TestGetAuthHeader(unittest.TestCase):
     def test_string_session_timeout_is_coerced(self, url_mock, cache_mock, time_mock):
         cache_mock.get.return_value = False
         time_mock.now.return_value = 1000
-        url_mock.fetch_json.side_effect = [SESSION_CREATED, (True, {'SessionTimeout': '300'})]
+        url_mock.fetch_json.side_effect = [
+            SESSION_CREATED,
+            (True, {'SessionTimeout': '300'}),
+        ]
         redfish.get_auth_header(_args(TIMEOUT=8), cache_expire=3600)
         self.assertEqual(cache_mock.set.call_args[0][2], 1000 + 292)
 
@@ -256,7 +269,10 @@ class TestGetAuthHeader(unittest.TestCase):
         # SessionTimeout below the margin would go negative; clamped to 1.
         cache_mock.get.return_value = False
         time_mock.now.return_value = 1000
-        url_mock.fetch_json.side_effect = [SESSION_CREATED, (True, {'SessionTimeout': 5})]
+        url_mock.fetch_json.side_effect = [
+            SESSION_CREATED,
+            (True, {'SessionTimeout': 5}),
+        ]
         redfish.get_auth_header(_args(TIMEOUT=8), cache_expire=3600)
         self.assertEqual(cache_mock.set.call_args[0][2], 1000 + 1)
 
@@ -287,13 +303,17 @@ class TestGetAuthHeader(unittest.TestCase):
 
     @mock.patch.object(redfish, 'cache')
     @mock.patch.object(redfish, 'url')
-    def test_session_creation_failure_falls_back_to_basic_auth(self, url_mock, cache_mock):
+    def test_session_creation_failure_falls_back_to_basic_auth(
+        self, url_mock, cache_mock
+    ):
         # No X-Auth-Token in the response header -> no session token.
         cache_mock.get.return_value = False
         url_mock.fetch_json.side_effect = [(False, 'Unauthorized')]
         header = redfish.get_auth_header(_args(), cache_expire=300)
         # 'linuxfabrik:linuxfabrik' base64-encoded.
-        self.assertEqual(header, {'Authorization': 'Basic bGludXhmYWJyaWs6bGludXhmYWJyaWs='})
+        self.assertEqual(
+            header, {'Authorization': 'Basic bGludXhmYWJyaWs6bGludXhmYWJyaWs='}
+        )
         # nothing is cached on the Basic-auth fallback
         cache_mock.set.assert_not_called()
         # Only the session-creation POST was attempted; no SessionService GET.
@@ -304,7 +324,9 @@ class TestGetAuthHeader(unittest.TestCase):
         # success but body is not a dict -> the isinstance guard rejects it.
         url_mock.fetch_json.side_effect = [(True, 'not-a-dict')]
         header = redfish.get_auth_header(_args())
-        self.assertEqual(header, {'Authorization': 'Basic bGludXhmYWJyaWs6bGludXhmYWJyaWs='})
+        self.assertEqual(
+            header, {'Authorization': 'Basic bGludXhmYWJyaWs6bGludXhmYWJyaWs='}
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1526,7 +1548,10 @@ class TestFetchCollection(unittest.TestCase):
 
     @mock.patch.object(redfish, 'url')
     def test_expand_non_dict_falls_back_to_plain(self, url_mock):
-        url_mock.fetch_json.side_effect = [(True, 'not-a-dict'), (True, {'Members': []})]
+        url_mock.fetch_json.side_effect = [
+            (True, 'not-a-dict'),
+            (True, {'Members': []}),
+        ]
         ok, out = redfish.fetch_collection('https://bmc/x')
         self.assertTrue(ok)
         self.assertEqual(out, {'Members': []})
@@ -1551,7 +1576,9 @@ class TestFetchCollection(unittest.TestCase):
     @mock.patch.object(redfish, 'time')
     @mock.patch.object(redfish, 'cache')
     @mock.patch.object(redfish, 'url')
-    def test_cache_miss_fetches_and_fills_by_plain_url(self, url_mock, cache_mock, time_mock):
+    def test_cache_miss_fetches_and_fills_by_plain_url(
+        self, url_mock, cache_mock, time_mock
+    ):
         cache_mock.get.return_value = False
         time_mock.now.return_value = 1000
         coll = {'Members': [{'@odata.id': '/x/1', 'Id': '1'}]}
@@ -1613,12 +1640,16 @@ class TestGetExpandSuffix(unittest.TestCase):
     @mock.patch.object(redfish, 'url')
     def test_no_expand_support_returns_default(self, url_mock):
         url_mock.fetch_json.return_value = (True, {'ProtocolFeaturesSupported': {}})
-        self.assertEqual(redfish.get_expand_suffix('https://bmc'), redfish.DEFAULT_EXPAND)
+        self.assertEqual(
+            redfish.get_expand_suffix('https://bmc'), redfish.DEFAULT_EXPAND
+        )
 
     @mock.patch.object(redfish, 'url')
     def test_unreadable_root_returns_default(self, url_mock):
         url_mock.fetch_json.return_value = (False, 'HTTP 500')
-        self.assertEqual(redfish.get_expand_suffix('https://bmc'), redfish.DEFAULT_EXPAND)
+        self.assertEqual(
+            redfish.get_expand_suffix('https://bmc'), redfish.DEFAULT_EXPAND
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1627,7 +1658,10 @@ class TestGetExpandSuffix(unittest.TestCase):
 class TestFetchMembers(unittest.TestCase):
     @mock.patch.object(redfish, 'url')
     def test_all_expanded_makes_no_requests(self, url_mock):
-        members = [{'@odata.id': '/x/1', 'Id': '1'}, {'@odata.id': '/x/2', 'Reading': 5}]
+        members = [
+            {'@odata.id': '/x/1', 'Id': '1'},
+            {'@odata.id': '/x/2', 'Reading': 5},
+        ]
         ok, out = redfish.fetch_members(members, 'https://bmc')
         self.assertTrue(ok)
         self.assertEqual(out, members)
@@ -1668,7 +1702,9 @@ class TestFetchMembers(unittest.TestCase):
     @mock.patch.object(redfish, 'url')
     def test_member_fetch_failure_propagates(self, url_mock):
         url_mock.fetch_json.return_value = (False, 'Bad Gateway')
-        ok, out = redfish.fetch_members([{'@odata.id': '/redfish/v1/x/1'}], 'https://bmc')
+        ok, out = redfish.fetch_members(
+            [{'@odata.id': '/redfish/v1/x/1'}], 'https://bmc'
+        )
         self.assertFalse(ok)
         self.assertEqual(out, 'Bad Gateway')
 

--- a/tests/shell/unit-test/run
+++ b/tests/shell/unit-test/run
@@ -32,6 +32,7 @@ import lib.shell as shell
 # Helpers / fakes
 # ---------------------------------------------------------------------------
 
+
 class FakePopen:
     """Minimal stand-in for subprocess.Popen.
 
@@ -86,6 +87,7 @@ def make_popen(stdout=b'', stderr=b'', returncode=0, timeout=False):
 # shell_exec() - argument type guard
 # ---------------------------------------------------------------------------
 
+
 class TestShellExecRequiresList(unittest.TestCase):
     def test_string_raises_type_error(self):
         with self.assertRaises(TypeError):
@@ -107,6 +109,7 @@ class TestShellExecRequiresList(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # shell_exec() - process wiring (mocked Popen)
 # ---------------------------------------------------------------------------
+
 
 class TestShellExec(unittest.TestCase):
     def test_single_command_success(self):
@@ -271,6 +274,7 @@ class TestShellExec(unittest.TestCase):
 # safe_cli_value()
 # ---------------------------------------------------------------------------
 
+
 class TestSafeCliValue(unittest.TestCase):
     def test_plain_value_passes(self):
         self.assertEqual(
@@ -302,6 +306,7 @@ class TestSafeCliValue(unittest.TestCase):
 # End-to-end smoke checks against trivial real commands (POSIX only).
 # These also assert the security property against a real subprocess.
 # ---------------------------------------------------------------------------
+
 
 @unittest.skipUnless(os.name == 'posix', 'POSIX-only smoke checks')
 class TestShellExecRealCommands(unittest.TestCase):

--- a/tests/smb/unit-test/run
+++ b/tests/smb/unit-test/run
@@ -45,6 +45,7 @@ except ImportError as exc:  # pragma: no cover - depends on venv contents
 # exactly what the module's isinstance()/strerror checks key off.
 # ----------------------------------------------------------------------------
 
+
 def make_smboserror(strerror, context=None):
     """Return a real SMBOSError with a controlled strerror and __context__."""
     # 0xC0000022 == STATUS_ACCESS_DENIED: any valid ntstatus works, we override
@@ -72,7 +73,10 @@ class TestGlobSuccess(unittest.TestCase):
         with patch.object(smb, 'smbclient') as cli:
             cli._os.SMBDirEntry.from_path.return_value = entry
             ok, result = smb.glob(
-                'smb://server/share/file.txt', 'user', 'pass', timeout=5,
+                'smb://server/share/file.txt',
+                'user',
+                'pass',
+                timeout=5,
             )
         self.assertTrue(ok)
         self.assertEqual(result, [entry])
@@ -99,7 +103,10 @@ class TestGlobSuccess(unittest.TestCase):
             cli._os.SMBDirEntry.from_path.return_value = dir_entry
             cli.scandir.return_value = iter(files)
             ok, result = smb.glob(
-                'smb://server/share/dir', 'user', 'pass', timeout=5,
+                'smb://server/share/dir',
+                'user',
+                'pass',
+                timeout=5,
             )
         self.assertTrue(ok)
         self.assertEqual(result, files)
@@ -111,8 +118,12 @@ class TestGlobSuccess(unittest.TestCase):
             cli._os.SMBDirEntry.from_path.return_value = dir_entry
             cli.scandir.return_value = iter([])
             smb.glob(
-                'smb://server/share/dir', 'user', 'pass', timeout=7,
-                pattern='*.log', encrypt=True,
+                'smb://server/share/dir',
+                'user',
+                'pass',
+                timeout=7,
+                pattern='*.log',
+                encrypt=True,
             )
         cli.scandir.assert_called_once_with(
             'smb://server/share/dir',
@@ -148,8 +159,7 @@ class TestGlobErrors(unittest.TestCase):
 
     def test_authentication_error(self):
         with patch.object(smb, 'smbclient') as cli:
-            cli._os.SMBDirEntry.from_path.side_effect = \
-                smbexc.SMBAuthenticationError()
+            cli._os.SMBDirEntry.from_path.side_effect = smbexc.SMBAuthenticationError()
             ok, msg = smb.glob('smb://s/f', 'user', 'pass', timeout=5)
         self.assertFalse(ok)
         self.assertEqual(msg, 'Login failed')
@@ -251,8 +261,7 @@ class TestOpenFileErrors(unittest.TestCase):
 
     def test_authentication_error_returns_str(self):
         with patch.object(smb, 'smbclient') as cli:
-            cli.open_file.side_effect = \
-                smbexc.SMBAuthenticationError('bad creds')
+            cli.open_file.side_effect = smbexc.SMBAuthenticationError('bad creds')
             ok, msg = smb.open_file('smb://s/f', 'user', 'pass', timeout=5)
         self.assertFalse(ok)
         self.assertEqual(msg, 'bad creds')

--- a/tests/ssh/unit-test/run
+++ b/tests/ssh/unit-test/run
@@ -108,9 +108,7 @@ class TestRun(unittest.TestCase):
         captured, fake = self._capture()
         with mock.patch('lib.ssh.shell.shell_exec', side_effect=fake):
             ssh.run('myhost', 'true', password='linuxfabrik')
-        self.assertEqual(
-            captured['cmd'][:3], ['sshpass', '-p', 'linuxfabrik']
-        )
+        self.assertEqual(captured['cmd'][:3], ['sshpass', '-p', 'linuxfabrik'])
         self.assertEqual(captured['cmd'][3], 'ssh')
 
     def test_rejects_option_like_host(self):
@@ -132,8 +130,9 @@ class TestScp(unittest.TestCase):
         captured = {}
         with mock.patch(
             'lib.ssh.shell.shell_exec',
-            side_effect=lambda cmd, timeout=None: captured.update(cmd=cmd)
-            or (True, ('', '', 0)),
+            side_effect=lambda cmd, timeout=None: (
+                captured.update(cmd=cmd) or (True, ('', '', 0))
+            ),
         ):
             ssh.scp('myhost', '/local/dir', '/remote/dir', recursive=True)
         cmd = captured['cmd']
@@ -146,12 +145,11 @@ class TestRsync(unittest.TestCase):
         captured = {}
         with mock.patch(
             'lib.ssh.shell.shell_exec',
-            side_effect=lambda cmd, timeout=None: captured.update(cmd=cmd)
-            or (True, ('', '', 0)),
+            side_effect=lambda cmd, timeout=None: (
+                captured.update(cmd=cmd) or (True, ('', '', 0))
+            ),
         ):
-            ssh.rsync(
-                'myhost', '/local/dir', '/remote/dir', options=['-q'], sudo=True
-            )
+            ssh.rsync('myhost', '/local/dir', '/remote/dir', options=['-q'], sudo=True)
         cmd = captured['cmd']
         self.assertEqual(cmd[:2], ['rsync', '--archive'])
         self.assertIn('--rsync-path', cmd)
@@ -164,8 +162,9 @@ class TestRsync(unittest.TestCase):
         captured = {}
         with mock.patch(
             'lib.ssh.shell.shell_exec',
-            side_effect=lambda cmd, timeout=None: captured.update(cmd=cmd)
-            or (True, ('', '', 0)),
+            side_effect=lambda cmd, timeout=None: (
+                captured.update(cmd=cmd) or (True, ('', '', 0))
+            ),
         ):
             ssh.rsync('myhost', '/local/dir', '/remote/dir')
         self.assertNotIn('--rsync-path', captured['cmd'])

--- a/tests/txt/unit-test/run
+++ b/tests/txt/unit-test/run
@@ -50,7 +50,9 @@ class TestExtractStr(unittest.TestCase):
         self.assertEqual(txt.extract_str('abcde', 'b', 'd'), 'c')
 
     def test_include_fromto(self):
-        self.assertEqual(txt.extract_str('abcde', 'b', 'x', include_fromto=True), 'bcde')
+        self.assertEqual(
+            txt.extract_str('abcde', 'b', 'x', include_fromto=True), 'bcde'
+        )
         self.assertEqual(txt.extract_str('abcde', 'b', 'd', include_fromto=True), 'bcd')
 
     def test_be_tolerant_combinations(self):
@@ -160,7 +162,9 @@ class TestToBytes(unittest.TestCase):
         self.assertEqual(txt.to_bytes(None, nonstring='empty'), b'')
 
     def test_errors_replace(self):
-        self.assertEqual(txt.to_bytes('café', encoding='ascii', errors='replace'), b'caf?')
+        self.assertEqual(
+            txt.to_bytes('café', encoding='ascii', errors='replace'), b'caf?'
+        )
 
 
 class TestToText(unittest.TestCase):
@@ -172,7 +176,9 @@ class TestToText(unittest.TestCase):
         self.assertEqual(txt.to_text(None, nonstring='empty'), '')
 
     def test_strict_or_latin1_valid_utf8(self):
-        self.assertEqual(txt.to_text('über'.encode(), errors='strict_or_latin1'), 'über')
+        self.assertEqual(
+            txt.to_text('über'.encode(), errors='strict_or_latin1'), 'über'
+        )
 
     def test_strict_or_latin1_falls_back_on_invalid_utf8(self):
         # 0xfc is ü in Latin-1/CP1252 and an invalid UTF-8 start byte. With
@@ -201,7 +207,9 @@ class TestUniq(unittest.TestCase):
     def test_dedups_tokens_preserving_order(self):
         self.assertEqual(txt.uniq('a a b a'), 'a b')
         self.assertEqual(
-            txt.uniq('This is a test. This is a second test. And this is a third test.'),
+            txt.uniq(
+                'This is a test. This is a second test. And this is a third test.'
+            ),
             'This is a test. second And this third',
         )
 

--- a/tests/uptimerobot/unit-test/run
+++ b/tests/uptimerobot/unit-test/run
@@ -67,6 +67,7 @@ import lib.uptimerobot as uptimerobot
 # Helpers
 # -----------------------------------------------------------------------------
 
+
 def ok(payload):
     """Build the (success, body) tuple lib.url.fetch_json returns on HTTP 200."""
     return (True, payload)
@@ -134,6 +135,7 @@ class UptimeRobotTestCase(unittest.TestCase):
 # Module surface
 # -----------------------------------------------------------------------------
 
+
 class TestModuleSurface(UptimeRobotTestCase):
     def test_public_functions_exist(self):
         for name in (
@@ -165,6 +167,7 @@ class TestModuleSurface(UptimeRobotTestCase):
 # get_data  (the core transport + pagination engine)
 # -----------------------------------------------------------------------------
 
+
 class TestGetData(UptimeRobotTestCase):
     def test_single_page_list_result(self):
         m = self.patch_fetch(ok(ok_envelope('monitors', [{'id': 1}, {'id': 2}])))
@@ -195,7 +198,9 @@ class TestGetData(UptimeRobotTestCase):
 
     def test_calls_given_uri(self):
         _m, store = self.capture_request(ok_envelope('monitors', [{'id': 1}]))
-        uptimerobot.get_data('https://example.com/api/foo', {'api_key': 'k'}, 'monitors')
+        uptimerobot.get_data(
+            'https://example.com/api/foo', {'api_key': 'k'}, 'monitors'
+        )
         self.assertEqual(store['uri'], 'https://example.com/api/foo')
 
     def test_dict_result_is_wrapped_in_list(self):
@@ -247,11 +252,13 @@ class TestGetData(UptimeRobotTestCase):
         def side(uri, **kwargs):
             off = kwargs['data']['offset']
             seen_offsets.append(off)
-            return ok({
-                'stat': 'ok',
-                'monitors': [{'id': off}],
-                'pagination': {'total': 120},
-            })
+            return ok(
+                {
+                    'stat': 'ok',
+                    'monitors': [{'id': off}],
+                    'pagination': {'total': 120},
+                }
+            )
 
         self.patch_fetch(side_effect=side)
         success, result = uptimerobot.get_data('http://x', {'api_key': 'k'}, 'monitors')
@@ -264,11 +271,13 @@ class TestGetData(UptimeRobotTestCase):
         # fetched at offset 50, after which 50 > 0 breaks. Two requests.
         def side(uri, **kwargs):
             off = kwargs['data']['offset']
-            return ok({
-                'stat': 'ok',
-                'monitors': [{'id': off}],
-                'pagination': {'total': 0},
-            })
+            return ok(
+                {
+                    'stat': 'ok',
+                    'monitors': [{'id': off}],
+                    'pagination': {'total': 0},
+                }
+            )
 
         m = self.patch_fetch(side_effect=side)
         success, result = uptimerobot.get_data('http://x', {'api_key': 'k'}, 'monitors')
@@ -280,11 +289,13 @@ class TestGetData(UptimeRobotTestCase):
         # Second page errors out; the partial result is discarded.
         def side(uri, **kwargs):
             if kwargs['data']['offset'] == 0:
-                return ok({
-                    'stat': 'ok',
-                    'monitors': [{'id': 0}],
-                    'pagination': {'total': 500},
-                })
+                return ok(
+                    {
+                        'stat': 'ok',
+                        'monitors': [{'id': 0}],
+                        'pagination': {'total': 500},
+                    }
+                )
             return fail('page 2 broke')
 
         self.patch_fetch(side_effect=side)
@@ -304,6 +315,7 @@ class TestGetData(UptimeRobotTestCase):
 # -----------------------------------------------------------------------------
 # get_response_header
 # -----------------------------------------------------------------------------
+
 
 class TestGetResponseHeader(UptimeRobotTestCase):
     def test_returns_response_header(self):
@@ -345,10 +357,14 @@ class TestGetResponseHeader(UptimeRobotTestCase):
 # delete_* endpoints (all share api_key/id filtering + a fixed URL)
 # -----------------------------------------------------------------------------
 
+
 class TestDeleteEndpoints(UptimeRobotTestCase):
     DELETE_CASES: typing.ClassVar = [
-        ('delete_alert_contact', 'https://api.uptimerobot.com/v2/deleteAlertContact',
-         'alert_contact'),
+        (
+            'delete_alert_contact',
+            'https://api.uptimerobot.com/v2/deleteAlertContact',
+            'alert_contact',
+        ),
         ('delete_monitor', 'https://api.uptimerobot.com/v2/deleteMonitor', 'monitor'),
         ('delete_mwindow', 'https://api.uptimerobot.com/v2/deleteMWindow', 'mwindow'),
         ('delete_psp', 'https://api.uptimerobot.com/v2/deletePSP', 'psp'),
@@ -400,6 +416,7 @@ class TestDeleteEndpoints(UptimeRobotTestCase):
 # edit_monitor / new_monitor (richest translation maps)
 # -----------------------------------------------------------------------------
 
+
 class TestEditMonitor(UptimeRobotTestCase):
     def test_url(self):
         _, store = self.capture_request(ok_envelope('monitor', {'id': 1}))
@@ -415,18 +432,20 @@ class TestEditMonitor(UptimeRobotTestCase):
 
     def test_translates_string_values(self):
         _, store = self.capture_request(ok_envelope('monitor', {'id': 1}))
-        uptimerobot.edit_monitor({
-            'api_key': 'k',
-            'id': 1,
-            'status': 'up',
-            'http_method': 'post',
-            'keyword_type': 'exist',
-            'keyword_case_type': 'ci',
-            'http_auth_type': 'digest',
-            'post_type': 'raw data',
-            'post_content_type': 'content/json',
-            'disable_domain_expire_notifications': 'disable',
-        })
+        uptimerobot.edit_monitor(
+            {
+                'api_key': 'k',
+                'id': 1,
+                'status': 'up',
+                'http_method': 'post',
+                'keyword_type': 'exist',
+                'keyword_case_type': 'ci',
+                'http_auth_type': 'digest',
+                'post_type': 'raw data',
+                'post_content_type': 'content/json',
+                'disable_domain_expire_notifications': 'disable',
+            }
+        )
         self.assertEqual(store['data']['status'], '1')
         self.assertEqual(store['data']['http_method'], '3')
         self.assertEqual(store['data']['keyword_type'], '1')
@@ -464,23 +483,27 @@ class TestEditMonitor(UptimeRobotTestCase):
 class TestNewMonitor(UptimeRobotTestCase):
     def test_url(self):
         _, store = self.capture_request(ok_envelope('monitor', {'id': 1}))
-        uptimerobot.new_monitor({'api_key': 'k', 'friendly_name': 'F', 'url': 'http://e'})
+        uptimerobot.new_monitor(
+            {'api_key': 'k', 'friendly_name': 'F', 'url': 'http://e'}
+        )
         self.assertEqual(store['uri'], 'https://api.uptimerobot.com/v2/newMonitor')
 
     def test_translates_type_and_methods(self):
         _, store = self.capture_request(ok_envelope('monitor', {'id': 1}))
-        uptimerobot.new_monitor({
-            'api_key': 'k',
-            'friendly_name': 'F',
-            'url': 'http://e',
-            'type': 'http',
-            'http_method': 'get',
-            'keyword_type': 'notex',
-            'keyword_case_type': 'cs',
-            'http_auth_type': 'basic',
-            'post_type': 'key-value',
-            'post_content_type': 'text/html',
-        })
+        uptimerobot.new_monitor(
+            {
+                'api_key': 'k',
+                'friendly_name': 'F',
+                'url': 'http://e',
+                'type': 'http',
+                'http_method': 'get',
+                'keyword_type': 'notex',
+                'keyword_case_type': 'cs',
+                'http_auth_type': 'basic',
+                'post_type': 'key-value',
+                'post_content_type': 'text/html',
+            }
+        )
         self.assertEqual(store['data']['type'], '1')
         self.assertEqual(store['data']['http_method'], '2')
         self.assertEqual(store['data']['keyword_type'], '2')
@@ -490,10 +513,17 @@ class TestNewMonitor(UptimeRobotTestCase):
         self.assertEqual(store['data']['post_content_type'], '0')
 
     def test_type_keyw_ping_port_beat(self):
-        for human, expected in (('keyw', '2'), ('ping', '3'), ('port', '4'), ('beat', '5')):
+        for human, expected in (
+            ('keyw', '2'),
+            ('ping', '3'),
+            ('port', '4'),
+            ('beat', '5'),
+        ):
             with self.subTest(type=human):
                 _, store = self.capture_request(ok_envelope('monitor', {'id': 1}))
-                uptimerobot.new_monitor({'api_key': 'k', 'url': 'http://e', 'type': human})
+                uptimerobot.new_monitor(
+                    {'api_key': 'k', 'url': 'http://e', 'type': human}
+                )
                 self.assertEqual(store['data']['type'], expected)
 
     def test_drops_id_key(self):
@@ -513,16 +543,19 @@ class TestNewMonitor(UptimeRobotTestCase):
 # edit_mwindow / new_mwindow
 # -----------------------------------------------------------------------------
 
+
 class TestMWindowWrite(UptimeRobotTestCase):
     def test_edit_mwindow_translation(self):
         _, store = self.capture_request(ok_envelope('mwindow', {'id': 1}))
-        uptimerobot.edit_mwindow({
-            'api_key': 'k',
-            'id': 1,
-            'type': 'daily',
-            'value': 'mon',
-            'status': 'active',
-        })
+        uptimerobot.edit_mwindow(
+            {
+                'api_key': 'k',
+                'id': 1,
+                'type': 'daily',
+                'value': 'mon',
+                'status': 'active',
+            }
+        )
         self.assertEqual(store['uri'], 'https://api.uptimerobot.com/v2/editMWindow')
         self.assertEqual(store['data']['type'], '2')
         self.assertEqual(store['data']['value'], '1')
@@ -535,14 +568,16 @@ class TestMWindowWrite(UptimeRobotTestCase):
 
     def test_new_mwindow_translation(self):
         _, store = self.capture_request(ok_envelope('mwindow', {'id': 1}))
-        uptimerobot.new_mwindow({
-            'api_key': 'k',
-            'friendly_name': 'W',
-            'type': 'once',
-            'value': 'tue',
-            'start_time': '2022-05-01T00:00:00',
-            'duration': 60,
-        })
+        uptimerobot.new_mwindow(
+            {
+                'api_key': 'k',
+                'friendly_name': 'W',
+                'type': 'once',
+                'value': 'tue',
+                'start_time': '2022-05-01T00:00:00',
+                'duration': 60,
+            }
+        )
         self.assertEqual(store['uri'], 'https://api.uptimerobot.com/v2/newMWindow')
         self.assertEqual(store['data']['type'], '1')
         self.assertEqual(store['data']['value'], '2')
@@ -550,7 +585,9 @@ class TestMWindowWrite(UptimeRobotTestCase):
     def test_new_mwindow_drops_status_and_id(self):
         # new_mwindow allows neither 'status' nor 'id'.
         _, store = self.capture_request(ok_envelope('mwindow', {'id': 1}))
-        uptimerobot.new_mwindow({'api_key': 'k', 'type': 'weekly', 'status': 'active', 'id': 7})
+        uptimerobot.new_mwindow(
+            {'api_key': 'k', 'type': 'weekly', 'status': 'active', 'id': 7}
+        )
         self.assertNotIn('status', store['data'])
         self.assertNotIn('id', store['data'])
         self.assertEqual(store['data']['type'], '3')
@@ -562,8 +599,13 @@ class TestMWindowWrite(UptimeRobotTestCase):
 
     def test_value_all_weekdays(self):
         for human, expected in (
-            ('mon', '1'), ('tue', '2'), ('wed', '3'), ('thu', '4'),
-            ('fri', '5'), ('sat', '6'), ('sun', '7'),
+            ('mon', '1'),
+            ('tue', '2'),
+            ('wed', '3'),
+            ('thu', '4'),
+            ('fri', '5'),
+            ('sat', '6'),
+            ('sun', '7'),
         ):
             with self.subTest(value=human):
                 _, store = self.capture_request(ok_envelope('mwindow', {'id': 1}))
@@ -575,22 +617,28 @@ class TestMWindowWrite(UptimeRobotTestCase):
 # edit_psp / new_psp
 # -----------------------------------------------------------------------------
 
+
 class TestPSPWrite(UptimeRobotTestCase):
     def test_edit_psp_translation(self):
         _, store = self.capture_request(ok_envelope('psp', {'id': 1}))
-        uptimerobot.edit_psp({
-            'api_key': 'k',
-            'id': 1,
-            'sort': 'a-z',
-            'status': 'active',
-        })
+        uptimerobot.edit_psp(
+            {
+                'api_key': 'k',
+                'id': 1,
+                'sort': 'a-z',
+                'status': 'active',
+            }
+        )
         self.assertEqual(store['uri'], 'https://api.uptimerobot.com/v2/editPSP')
         self.assertEqual(store['data']['sort'], '1')
         self.assertEqual(store['data']['status'], '1')
 
     def test_edit_psp_sort_variants(self):
         for human, expected in (
-            ('a-z', '1'), ('z-a', '2'), ('up-down-paused', '3'), ('down-up-paused', '4'),
+            ('a-z', '1'),
+            ('z-a', '2'),
+            ('up-down-paused', '3'),
+            ('down-up-paused', '4'),
         ):
             with self.subTest(sort=human):
                 _, store = self.capture_request(ok_envelope('psp', {'id': 1}))
@@ -611,20 +659,28 @@ class TestPSPWrite(UptimeRobotTestCase):
 
     def test_new_psp_keeps_allowed_keys(self):
         _, store = self.capture_request(ok_envelope('psp', {'id': 1}))
-        uptimerobot.new_psp({
-            'api_key': 'k',
-            'friendly_name': 'P',
-            'monitors': '1-2-3',
-            'custom_domain': 'status.example.com',
-            'password': 'linuxfabrik',
-            'hide_url_links': '1',
-            'junk': 'drop',
-        })
+        uptimerobot.new_psp(
+            {
+                'api_key': 'k',
+                'friendly_name': 'P',
+                'monitors': '1-2-3',
+                'custom_domain': 'status.example.com',
+                'password': 'linuxfabrik',
+                'hide_url_links': '1',
+                'junk': 'drop',
+            }
+        )
         self.assertEqual(
             set(store['data'].keys()),
             {
-                'api_key', 'friendly_name', 'monitors', 'custom_domain',
-                'password', 'hide_url_links', 'format', 'offset',
+                'api_key',
+                'friendly_name',
+                'monitors',
+                'custom_domain',
+                'password',
+                'hide_url_links',
+                'format',
+                'offset',
             },
         )
 
@@ -632,6 +688,7 @@ class TestPSPWrite(UptimeRobotTestCase):
 # -----------------------------------------------------------------------------
 # get_monitors (longest result-translation path)
 # -----------------------------------------------------------------------------
+
 
 class TestGetMonitors(UptimeRobotTestCase):
     def test_url(self):
@@ -651,42 +708,57 @@ class TestGetMonitors(UptimeRobotTestCase):
         self.assertNotIn('junk', store['data'])
 
     def test_result_translation_known_values(self):
-        payload = ok_envelope('monitors', [{
-            'id': 1,
-            'status': 2,
-            'type': 1,
-            'http_method': 3,
-            'keyword_type': 1,
-            'keyword_case_type': 0,
-            'auth_type': 1,
-            'alert_contacts': [{'type': 2}],
-        }])
+        payload = ok_envelope(
+            'monitors',
+            [
+                {
+                    'id': 1,
+                    'status': 2,
+                    'type': 1,
+                    'http_method': 3,
+                    'keyword_type': 1,
+                    'keyword_case_type': 0,
+                    'auth_type': 1,
+                    'alert_contacts': [{'type': 2}],
+                }
+            ],
+        )
         self.patch_fetch(ok(payload))
         success, result = uptimerobot.get_monitors({'api_key': 'k'})
         self.assertTrue(success)
-        self.assertEqual(result, [{
-            'id': 1,
-            'status': 'up',
-            'type': 'http',
-            'http_method': 'post',
-            'keyword_type': 'exist',
-            'keyword_case_type': 'cs',
-            'auth_type': 'basic',
-            'alert_contacts': [{'type': 'e-mail'}],
-        }])
+        self.assertEqual(
+            result,
+            [
+                {
+                    'id': 1,
+                    'status': 'up',
+                    'type': 'http',
+                    'http_method': 'post',
+                    'keyword_type': 'exist',
+                    'keyword_case_type': 'cs',
+                    'auth_type': 'basic',
+                    'alert_contacts': [{'type': 'e-mail'}],
+                }
+            ],
+        )
 
     def test_result_translation_unknown_values(self):
         # status/type/http_method/keyword_case_type keep the unknown value;
         # keyword_type and auth_type fall back to the literal 'None'.
-        payload = ok_envelope('monitors', [{
-            'id': 1,
-            'status': 99,
-            'type': 99,
-            'http_method': 99,
-            'keyword_case_type': 99,
-            'keyword_type': 99,
-            'auth_type': 99,
-        }])
+        payload = ok_envelope(
+            'monitors',
+            [
+                {
+                    'id': 1,
+                    'status': 99,
+                    'type': 99,
+                    'http_method': 99,
+                    'keyword_case_type': 99,
+                    'keyword_type': 99,
+                    'auth_type': 99,
+                }
+            ],
+        )
         self.patch_fetch(ok(payload))
         _, result = uptimerobot.get_monitors({'api_key': 'k'})
         item = result[0]
@@ -698,7 +770,9 @@ class TestGetMonitors(UptimeRobotTestCase):
         self.assertEqual(item['auth_type'], 'None')
 
     def test_alert_contact_unknown_type_kept(self):
-        payload = ok_envelope('monitors', [{'id': 1, 'alert_contacts': [{'type': 999}]}])
+        payload = ok_envelope(
+            'monitors', [{'id': 1, 'alert_contacts': [{'type': 999}]}]
+        )
         self.patch_fetch(ok(payload))
         _, result = uptimerobot.get_monitors({'api_key': 'k'})
         self.assertEqual(result[0]['alert_contacts'][0]['type'], 999)
@@ -733,26 +807,35 @@ class TestGetMonitors(UptimeRobotTestCase):
 # get_alert_contacts
 # -----------------------------------------------------------------------------
 
+
 class TestGetAlertContacts(UptimeRobotTestCase):
     def test_url_and_key_filtering(self):
         _, store = self.capture_request(ok_envelope('alert_contacts', []))
         uptimerobot.get_alert_contacts({'api_key': 'k', 'limit': 10, 'junk': 1})
-        self.assertEqual(store['uri'], 'https://api.uptimerobot.com/v2/getAlertContacts')
+        self.assertEqual(
+            store['uri'], 'https://api.uptimerobot.com/v2/getAlertContacts'
+        )
         self.assertNotIn('junk', store['data'])
         self.assertEqual(store['data']['limit'], 10)
 
     def test_result_translation_known(self):
-        payload = ok_envelope('alert_contacts', [
-            {'id': 1, 'status': 2, 'type': 2},
-            {'id': 2, 'status': 1, 'type': 11},
-        ])
+        payload = ok_envelope(
+            'alert_contacts',
+            [
+                {'id': 1, 'status': 2, 'type': 2},
+                {'id': 2, 'status': 1, 'type': 11},
+            ],
+        )
         self.patch_fetch(ok(payload))
         success, result = uptimerobot.get_alert_contacts({'api_key': 'k'})
         self.assertTrue(success)
-        self.assertEqual(result, [
-            {'id': 1, 'status': 'active', 'type': 'e-mail'},
-            {'id': 2, 'status': 'paused', 'type': 'slack'},
-        ])
+        self.assertEqual(
+            result,
+            [
+                {'id': 1, 'status': 'active', 'type': 'e-mail'},
+                {'id': 2, 'status': 'paused', 'type': 'slack'},
+            ],
+        )
 
     def test_result_translation_unknown_falls_back_to_none(self):
         payload = ok_envelope('alert_contacts', [{'id': 1, 'status': 99, 'type': 99}])
@@ -769,7 +852,9 @@ class TestGetAlertContacts(UptimeRobotTestCase):
         self.assertEqual(result[0]['type'], 'sms')
 
     def test_single_dict_wrapped_and_translated(self):
-        self.patch_fetch(ok(ok_envelope('alert_contacts', {'id': 1, 'status': 2, 'type': 1})))
+        self.patch_fetch(
+            ok(ok_envelope('alert_contacts', {'id': 1, 'status': 2, 'type': 1}))
+        )
         _, result = uptimerobot.get_alert_contacts({'api_key': 'k'})
         self.assertEqual(result, [{'id': 1, 'status': 'active', 'type': 'sms'}])
 
@@ -790,6 +875,7 @@ class TestGetAlertContacts(UptimeRobotTestCase):
 # get_mwindows
 # -----------------------------------------------------------------------------
 
+
 class TestGetMWindows(UptimeRobotTestCase):
     def test_url_and_key_filtering(self):
         _, store = self.capture_request(ok_envelope('mwindows', []))
@@ -799,19 +885,25 @@ class TestGetMWindows(UptimeRobotTestCase):
         self.assertEqual(store['data']['mwindows'], '1-2')
 
     def test_result_translation(self):
-        payload = ok_envelope('mwindows', [
-            {'id': 1, 'status': 1},
-            {'id': 2, 'status': 0},
-            {'id': 3, 'status': 99},
-        ])
+        payload = ok_envelope(
+            'mwindows',
+            [
+                {'id': 1, 'status': 1},
+                {'id': 2, 'status': 0},
+                {'id': 3, 'status': 99},
+            ],
+        )
         self.patch_fetch(ok(payload))
         success, result = uptimerobot.get_mwindows({'api_key': 'k'})
         self.assertTrue(success)
-        self.assertEqual(result, [
-            {'id': 1, 'status': 'active'},
-            {'id': 2, 'status': 'paused'},
-            {'id': 3, 'status': 'None'},
-        ])
+        self.assertEqual(
+            result,
+            [
+                {'id': 1, 'status': 'active'},
+                {'id': 2, 'status': 'paused'},
+                {'id': 3, 'status': 'None'},
+            ],
+        )
 
     def test_api_error_returns_two_tuple(self):
         self.patch_fetch(ok(ERROR_ENVELOPE))
@@ -830,6 +922,7 @@ class TestGetMWindows(UptimeRobotTestCase):
 # get_psps
 # -----------------------------------------------------------------------------
 
+
 class TestGetPSPs(UptimeRobotTestCase):
     def test_url_and_key_filtering(self):
         _, store = self.capture_request(ok_envelope('psps', []))
@@ -839,19 +932,25 @@ class TestGetPSPs(UptimeRobotTestCase):
         self.assertEqual(store['data']['psps'], '1')
 
     def test_result_translation(self):
-        payload = ok_envelope('psps', [
-            {'id': 1, 'sort': 1, 'status': 1},
-            {'id': 2, 'sort': 4, 'status': 0},
-            {'id': 3, 'sort': 99, 'status': 99},
-        ])
+        payload = ok_envelope(
+            'psps',
+            [
+                {'id': 1, 'sort': 1, 'status': 1},
+                {'id': 2, 'sort': 4, 'status': 0},
+                {'id': 3, 'sort': 99, 'status': 99},
+            ],
+        )
         self.patch_fetch(ok(payload))
         success, result = uptimerobot.get_psps({'api_key': 'k'})
         self.assertTrue(success)
-        self.assertEqual(result, [
-            {'id': 1, 'sort': 'a-z', 'status': 'active'},
-            {'id': 2, 'sort': 'down-up-paused', 'status': 'paused'},
-            {'id': 3, 'sort': 'None', 'status': 'None'},
-        ])
+        self.assertEqual(
+            result,
+            [
+                {'id': 1, 'sort': 'a-z', 'status': 'active'},
+                {'id': 2, 'sort': 'down-up-paused', 'status': 'paused'},
+                {'id': 3, 'sort': 'None', 'status': 'None'},
+            ],
+        )
 
     def test_api_error_returns_two_tuple(self):
         self.patch_fetch(ok(ERROR_ENVELOPE))
@@ -870,19 +969,25 @@ class TestGetPSPs(UptimeRobotTestCase):
 # get_account_details (two fetch_json calls: header then data)
 # -----------------------------------------------------------------------------
 
+
 class TestGetAccountDetails(UptimeRobotTestCase):
     def _two_call_side_effect(self, header_value, data_payload):
         def side(uri, **kwargs):
             if kwargs.get('extended'):
                 return ok({'response_header': header_value})
             return ok(data_payload)
+
         return side
 
     def test_returns_three_tuple_on_success(self):
-        self.patch_fetch(side_effect=self._two_call_side_effect(
-            {'X-RateLimit-Remaining': '10'},
-            ok_envelope('account', {'email': 'user@example.com', 'monitor_limit': 50}),
-        ))
+        self.patch_fetch(
+            side_effect=self._two_call_side_effect(
+                {'X-RateLimit-Remaining': '10'},
+                ok_envelope(
+                    'account', {'email': 'user@example.com', 'monitor_limit': 50}
+                ),
+            )
+        )
         result = uptimerobot.get_account_details({'api_key': 'k'})
         self.assertEqual(len(result), 3)
         success, account, rl = result
@@ -892,18 +997,24 @@ class TestGetAccountDetails(UptimeRobotTestCase):
         self.assertEqual(rl, {'X-RateLimit-Remaining': '10'})
 
     def test_makes_two_requests_header_then_data(self):
-        m = self.patch_fetch(side_effect=self._two_call_side_effect(
-            {}, ok_envelope('account', {'email': 'a@b.c'}),
-        ))
+        m = self.patch_fetch(
+            side_effect=self._two_call_side_effect(
+                {},
+                ok_envelope('account', {'email': 'a@b.c'}),
+            )
+        )
         uptimerobot.get_account_details({'api_key': 'k'})
         self.assertEqual(m.call_count, 2)
         self.assertTrue(m.call_args_list[0].kwargs['extended'])
         self.assertIsNone(m.call_args_list[1].kwargs.get('extended'))
 
     def test_both_requests_target_account_endpoint(self):
-        m = self.patch_fetch(side_effect=self._two_call_side_effect(
-            {}, ok_envelope('account', {'email': 'a@b.c'}),
-        ))
+        m = self.patch_fetch(
+            side_effect=self._two_call_side_effect(
+                {},
+                ok_envelope('account', {'email': 'a@b.c'}),
+            )
+        )
         uptimerobot.get_account_details({'api_key': 'k'})
         for call in m.call_args_list:
             self.assertEqual(
@@ -912,9 +1023,12 @@ class TestGetAccountDetails(UptimeRobotTestCase):
             )
 
     def test_filters_input_to_api_key_only(self):
-        m = self.patch_fetch(side_effect=self._two_call_side_effect(
-            {}, ok_envelope('account', {'email': 'a@b.c'}),
-        ))
+        m = self.patch_fetch(
+            side_effect=self._two_call_side_effect(
+                {},
+                ok_envelope('account', {'email': 'a@b.c'}),
+            )
+        )
         uptimerobot.get_account_details({'api_key': 'k', 'junk': 'x', 'limit': 5})
         # The header request body keeps only api_key (+ injected format).
         header_data = m.call_args_list[0].kwargs['data']
@@ -923,9 +1037,12 @@ class TestGetAccountDetails(UptimeRobotTestCase):
         self.assertEqual(header_data['api_key'], 'k')
 
     def test_mutates_input_dict_in_place(self):
-        self.patch_fetch(side_effect=self._two_call_side_effect(
-            {}, ok_envelope('account', {'email': 'a@b.c'}),
-        ))
+        self.patch_fetch(
+            side_effect=self._two_call_side_effect(
+                {},
+                ok_envelope('account', {'email': 'a@b.c'}),
+            )
+        )
         data = {'api_key': 'k', 'junk': 'x'}
         uptimerobot.get_account_details(data)
         # 'junk' was popped, format/offset injected by get_data.

--- a/tests/wildfly/unit-test/run
+++ b/tests/wildfly/unit-test/run
@@ -120,7 +120,6 @@ def run_get_data(args, data=None, uri='', *, fetch_return):
 
 
 class TestUrlConstruction(unittest.TestCase):
-
     def test_standalone_base_plus_management(self):
         args = make_args(URL='https://wf.example.com', MODE='standalone')
         _, _, m, _ = run_get_data(args, uri='', fetch_return=(True, ok(1)))
@@ -152,14 +151,18 @@ class TestUrlConstruction(unittest.TestCase):
         # The module does not insert a separator; document the real behaviour.
         args = make_args()
         _, _, m, _ = run_get_data(args, uri='subsystem', fetch_return=(True, ok(1)))
-        self.assertEqual(m.call_args.args[0], 'https://wf.example.com/managementsubsystem')
+        self.assertEqual(
+            m.call_args.args[0], 'https://wf.example.com/managementsubsystem'
+        )
 
     def test_uri_default_is_empty(self):
         # Calling get_data without the uri argument must behave like uri=''.
         args = make_args()
         buf = io.StringIO()
         with (
-            mock.patch.object(wildfly.url, 'fetch_json', return_value=(True, ok(1))) as m,
+            mock.patch.object(
+                wildfly.url, 'fetch_json', return_value=(True, ok(1))
+            ) as m,
             contextlib.redirect_stdout(buf),
         ):
             wildfly.get_data(args, {'operation': 'x'})
@@ -183,7 +186,9 @@ class TestUrlConstruction(unittest.TestCase):
         )
 
     def test_domain_mode_strips_base_trailing_slash(self):
-        args = make_args(URL='https://wf.example.com/', MODE='domain', NODE='h', INSTANCE='s')
+        args = make_args(
+            URL='https://wf.example.com/', MODE='domain', NODE='h', INSTANCE='s'
+        )
         _, _, m, _ = run_get_data(args, uri='', fetch_return=(True, ok(1)))
         self.assertEqual(
             m.call_args.args[0],
@@ -203,11 +208,12 @@ class TestUrlConstruction(unittest.TestCase):
 
 
 class TestRequestConstruction(unittest.TestCase):
-
     def test_content_type_header(self):
         args = make_args()
         _, _, m, _ = run_get_data(args, fetch_return=(True, ok(1)))
-        self.assertEqual(m.call_args.kwargs['header'], {'Content-Type': 'application/json'})
+        self.assertEqual(
+            m.call_args.kwargs['header'], {'Content-Type': 'application/json'}
+        )
 
     def test_digest_auth_user_and_password(self):
         args = make_args(USERNAME='svc', PASSWORD='s3cr3t')
@@ -258,8 +264,13 @@ class TestRequestConstruction(unittest.TestCase):
     def test_full_kwargs_shape(self):
         # Pin the exact contract handed to fetch_json so an accidental rename or
         # dropped argument is caught immediately.
-        args = make_args(USERNAME='admin', PASSWORD='linuxfabrik',
-                         INSECURE=True, NO_PROXY=True, TIMEOUT=20)
+        args = make_args(
+            USERNAME='admin',
+            PASSWORD='linuxfabrik',
+            INSECURE=True,
+            NO_PROXY=True,
+            TIMEOUT=20,
+        )
         body = {'operation': 'read-attribute', 'name': 'server-state'}
         _, _, m, _ = run_get_data(args, data=body, fetch_return=(True, ok(1)))
         self.assertEqual(
@@ -294,7 +305,6 @@ class TestRequestConstruction(unittest.TestCase):
 
 
 class TestSuccessParsing(unittest.TestCase):
-
     def test_returns_inner_result_scalar(self):
         # get_data unwraps result['result'], not the whole envelope.
         args = make_args()
@@ -353,7 +363,6 @@ class TestSuccessParsing(unittest.TestCase):
 
 
 class TestOutcomeErrorHandling(unittest.TestCase):
-
     def test_outcome_failed_exits_unknown(self):
         args = make_args(ALWAYS_OK=False)
         payload = {'outcome': 'failed', 'failure-description': 'oops'}
@@ -400,9 +409,12 @@ class TestOutcomeErrorHandling(unittest.TestCase):
         # unconditionally, so a KeyError surfaces (documented behaviour, not a
         # graceful exit).
         args = make_args()
-        with mock.patch.object(
-            wildfly.url, 'fetch_json', return_value=(True, {'outcome': 'success'})
-        ), self.assertRaises(KeyError):
+        with (
+            mock.patch.object(
+                wildfly.url, 'fetch_json', return_value=(True, {'outcome': 'success'})
+            ),
+            self.assertRaises(KeyError),
+        ):
             wildfly.get_data(args, {'operation': 'x'}, '')
 
 
@@ -412,7 +424,6 @@ class TestOutcomeErrorHandling(unittest.TestCase):
 
 
 class TestTransportErrorHandling(unittest.TestCase):
-
     def test_connection_refused_exits_unknown(self):
         args = make_args()
         returned, raised, _, out = run_get_data(
@@ -468,7 +479,6 @@ class TestTransportErrorHandling(unittest.TestCase):
 
 
 class TestModuleSanity(unittest.TestCase):
-
     def test_get_data_is_callable(self):
         self.assertTrue(callable(wildfly.get_data))
 

--- a/tests/winrm/unit-test/run
+++ b/tests/winrm/unit-test/run
@@ -49,6 +49,7 @@ except ImportError as exc:  # pragma: no cover - only if the repo layout breaks
 # Fixtures / helpers
 # ----------------------------------------------------------------------------
 
+
 class Args:
     """Minimal argparse.Namespace stand-in with the WINRM_* attributes.
 
@@ -165,9 +166,9 @@ def make_error_record(to_string=None, message=None, raise_on_to_string=False):
 # _build_auth
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestBuildAuth(unittest.TestCase):
-
     def test_basic_username_password(self):
         args = make_args(WINRM_TRANSPORT='basic')
         self.assertEqual(
@@ -198,7 +199,9 @@ class TestBuildAuth(unittest.TestCase):
         self.assertEqual(winrm_lib._build_auth(args), (None, None))
 
     def test_negotiate_missing_creds_falls_back_to_ccache(self):
-        args = make_args(WINRM_TRANSPORT='negotiate', WINRM_USERNAME='', WINRM_PASSWORD='')
+        args = make_args(
+            WINRM_TRANSPORT='negotiate', WINRM_USERNAME='', WINRM_PASSWORD=''
+        )
         self.assertEqual(winrm_lib._build_auth(args), (None, None))
 
     def test_transport_case_insensitive(self):
@@ -230,9 +233,9 @@ class TestBuildAuth(unittest.TestCase):
 # _map_transport
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestMapTransport(unittest.TestCase):
-
     def test_ssl_uses_basic_auth_ssl_true_port_5986(self):
         args = make_args(WINRM_TRANSPORT='ssl')
         self.assertEqual(winrm_lib._map_transport(args), ('basic', True, 5986))
@@ -274,9 +277,9 @@ class TestMapTransport(unittest.TestCase):
 # _quote_ps_value
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestQuotePsValue(unittest.TestCase):
-
     def test_plain_string_is_single_quoted(self):
         self.assertEqual(winrm_lib._quote_ps_value('WinRM'), "'WinRM'")
 
@@ -297,9 +300,9 @@ class TestQuotePsValue(unittest.TestCase):
 # run_cmd - pypsrp (JEA) backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunCmdJea(unittest.TestCase):
-
     def test_success_returns_normalized_dict(self):
         session = MagicMock(name='Client-instance')
         session.execute_cmd.return_value = ('out', 'err', 0)
@@ -347,7 +350,9 @@ class TestRunCmdJea(unittest.TestCase):
         session = MagicMock()
         session.execute_cmd.return_value = ('', '', 0)
         client_cls = MagicMock(return_value=session)
-        args = make_args(WINRM_TRANSPORT='kerberos', WINRM_USERNAME='', WINRM_PASSWORD='')
+        args = make_args(
+            WINRM_TRANSPORT='kerberos', WINRM_USERNAME='', WINRM_PASSWORD=''
+        )
         with force_jea(), patch.object(winrm_lib, 'Client', client_cls, create=True):
             winrm_lib.run_cmd(args, 'hostname')
         _, kwargs = client_cls.call_args
@@ -399,16 +404,18 @@ class TestRunCmdJea(unittest.TestCase):
 # run_cmd - pywinrm backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunCmdPywinrm(unittest.TestCase):
-
     def test_success(self):
         session = MagicMock(name='winrm.Session-instance')
         session.run_cmd.return_value = make_pywinrm_result(0, b'out', b'')
         winrm_mock = MagicMock(name='winrm-module')
         winrm_mock.Session.return_value = session
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_cmd(make_args(), 'ipconfig', ['/all'])
         self.assertEqual(result, {'retc': 0, 'stdout': 'out', 'stderr': ''})
         session.run_cmd.assert_called_once_with('ipconfig', ['/all'])
@@ -419,8 +426,10 @@ class TestRunCmdPywinrm(unittest.TestCase):
         winrm_mock = MagicMock()
         winrm_mock.Session.return_value = session
         args = make_args(WINRM_TRANSPORT='ntlm', WINRM_DOMAIN='corp')
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_cmd(args, 'hostname')
         winrm_mock.Session.assert_called_once_with(
             'win.example.com',
@@ -433,16 +442,20 @@ class TestRunCmdPywinrm(unittest.TestCase):
         session.run_cmd.return_value = make_pywinrm_result(2, b'', b'fail')
         winrm_mock = MagicMock()
         winrm_mock.Session.return_value = session
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_cmd(make_args(), 'hostname')
         self.assertEqual(result, {'retc': 2, 'stdout': '', 'stderr': 'fail'})
 
     def test_exception_normalized(self):
         winrm_mock = MagicMock()
         winrm_mock.Session.side_effect = RuntimeError('no route to host')
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_cmd(make_args(), 'hostname')
         self.assertEqual(result['retc'], 1)
         self.assertIn('no route to host', result['stderr'])
@@ -452,8 +465,10 @@ class TestRunCmdPywinrm(unittest.TestCase):
         session.run_cmd.return_value = make_pywinrm_result(0, b'', b'')
         winrm_mock = MagicMock()
         winrm_mock.Session.return_value = session
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_cmd(make_args(), 'hostname')
         session.run_cmd.assert_called_once_with('hostname', [])
 
@@ -462,9 +477,9 @@ class TestRunCmdPywinrm(unittest.TestCase):
 # run_cmd - no backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunCmdNoBackend(unittest.TestCase):
-
     def test_returns_clear_error(self):
         with force_jea(have_jea=False, have_winrm=False):
             result = winrm_lib.run_cmd(make_args(), 'hostname')
@@ -477,14 +492,15 @@ class TestRunCmdNoBackend(unittest.TestCase):
 # run_ps - pypsrp (JEA) backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunPsJea(unittest.TestCase):
-
     def _run(self, args, cmd, params, powershell):
         """Wire up the lazily imported pypsrp symbols and call run_ps."""
         pool = make_runspace_pool(powershell)
-        patches, runspace_cls, powershell_cls, wsman_cls, created = \
+        patches, runspace_cls, powershell_cls, wsman_cls, created = (
             patch_pypsrp_powershell(pool, powershell)
+        )
         try:
             with force_jea():
                 for p in patches:
@@ -502,7 +518,10 @@ class TestRunPsJea(unittest.TestCase):
     def test_script_path_uses_add_script(self):
         ps = make_powershell(outputs=['line1', 'line2'])
         result, _, _, _, _ = self._run(
-            make_args(), 'Get-Process | Select -First 1', None, ps,
+            make_args(),
+            'Get-Process | Select -First 1',
+            None,
+            ps,
         )
         self.assertEqual(result, {'retc': 0, 'stdout': 'line1\nline2', 'stderr': ''})
         ps.add_script.assert_called_once_with('Get-Process | Select -First 1')
@@ -519,7 +538,10 @@ class TestRunPsJea(unittest.TestCase):
     def test_dict_params_use_add_parameter(self):
         ps = make_powershell(outputs=['ok'])
         result, _, _, _, _ = self._run(
-            make_args(), 'Get-WmiObject', {'Class': 'Win32_OperatingSystem'}, ps,
+            make_args(),
+            'Get-WmiObject',
+            {'Class': 'Win32_OperatingSystem'},
+            ps,
         )
         self.assertEqual(result['retc'], 0)
         ps.add_cmdlet.assert_called_once_with('Get-WmiObject')
@@ -624,9 +646,9 @@ class TestRunPsJea(unittest.TestCase):
 # run_ps - configuration name without pypsrp
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunPsConfigurationGuard(unittest.TestCase):
-
     def test_configuration_name_without_jea_is_rejected(self):
         args = make_args(WINRM_CONFIGURATION_NAME='LF.JEA')
         with force_jea(have_jea=False, have_winrm=True):
@@ -656,9 +678,9 @@ class TestRunPsConfigurationGuard(unittest.TestCase):
 # run_ps - pywinrm backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunPsPywinrm(unittest.TestCase):
-
     def _session(self, result):
         session = MagicMock(name='winrm.Session-instance')
         session.run_ps.return_value = result
@@ -668,32 +690,42 @@ class TestRunPsPywinrm(unittest.TestCase):
 
     def test_script_path_passes_cmd_verbatim(self):
         session, winrm_mock = self._session(make_pywinrm_result(0, b'out', b''))
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)
         self.assertEqual(result, {'retc': 0, 'stdout': 'out', 'stderr': ''})
         session.run_ps.assert_called_once_with('Get-Date')
 
     def test_positional_params_are_appended(self):
         session, winrm_mock = self._session(make_pywinrm_result(0, b'', b''))
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_ps(make_args(), 'Get-Service', ['WinRM', 'Spooler'])
         session.run_ps.assert_called_once_with('Get-Service WinRM Spooler')
 
     def test_empty_positional_params_keeps_bare_cmd(self):
         session, winrm_mock = self._session(make_pywinrm_result(0, b'', b''))
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_ps(make_args(), 'Get-Date', [])
         session.run_ps.assert_called_once_with('Get-Date')
 
     def test_dict_params_are_quoted(self):
         session, winrm_mock = self._session(make_pywinrm_result(0, b'', b''))
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_ps(
-                make_args(), 'Get-WmiObject', {'Class': 'Win32_OperatingSystem'},
+                make_args(),
+                'Get-WmiObject',
+                {'Class': 'Win32_OperatingSystem'},
             )
         session.run_ps.assert_called_once_with(
             "Get-WmiObject -Class 'Win32_OperatingSystem'",
@@ -701,16 +733,20 @@ class TestRunPsPywinrm(unittest.TestCase):
 
     def test_dict_params_escape_single_quotes(self):
         session, winrm_mock = self._session(make_pywinrm_result(0, b'', b''))
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_ps(make_args(), 'Get-Thing', {'Name': "O'Brien"})
         session.run_ps.assert_called_once_with("Get-Thing -Name 'O''Brien'")
 
     def test_clixml_noise_suppressed_on_success(self):
         result_obj = make_pywinrm_result(0, b'data', b'#< CLIXML\r\n<Objs>...')
         _, winrm_mock = self._session(result_obj)
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)
         self.assertEqual(result['retc'], 0)
         self.assertEqual(result['stderr'], '')
@@ -718,8 +754,10 @@ class TestRunPsPywinrm(unittest.TestCase):
     def test_clixml_noise_kept_on_failure(self):
         result_obj = make_pywinrm_result(1, b'', b'#< CLIXML\r\nreal error')
         _, winrm_mock = self._session(result_obj)
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)
         self.assertEqual(result['retc'], 1)
         self.assertTrue(result['stderr'].startswith('#< CLIXML'))
@@ -727,16 +765,20 @@ class TestRunPsPywinrm(unittest.TestCase):
     def test_non_clixml_stderr_kept_on_success(self):
         result_obj = make_pywinrm_result(0, b'', b'plain warning')
         _, winrm_mock = self._session(result_obj)
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)
         self.assertEqual(result['stderr'], 'plain warning')
 
     def test_exception_is_normalized(self):
         winrm_mock = MagicMock()
         winrm_mock.Session.side_effect = RuntimeError('ps failed')
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)
         self.assertEqual(result['retc'], 1)
         self.assertIn('ps failed', result['stderr'])
@@ -744,8 +786,10 @@ class TestRunPsPywinrm(unittest.TestCase):
     def test_session_built_with_auth_and_transport(self):
         _, winrm_mock = self._session(make_pywinrm_result(0, b'', b''))
         args = make_args(WINRM_TRANSPORT='basic')
-        with force_jea(have_jea=False, have_winrm=True), \
-                patch.object(winrm_lib, 'winrm', winrm_mock, create=True):
+        with (
+            force_jea(have_jea=False, have_winrm=True),
+            patch.object(winrm_lib, 'winrm', winrm_mock, create=True),
+        ):
             winrm_lib.run_ps(args, 'Get-Date', None)
         winrm_mock.Session.assert_called_once_with(
             'win.example.com',
@@ -758,9 +802,9 @@ class TestRunPsPywinrm(unittest.TestCase):
 # run_ps - no backend
 # ============================================================================
 
+
 @unittest.skipUnless(HAVE_MODULE, 'lib.winrm import failed: ' + IMPORT_ERROR)
 class TestRunPsNoBackend(unittest.TestCase):
-
     def test_returns_clear_error(self):
         with force_jea(have_jea=False, have_winrm=False):
             result = winrm_lib.run_ps(make_args(), 'Get-Date', None)

--- a/tools/run-all-tests
+++ b/tools/run-all-tests
@@ -67,15 +67,25 @@ def main():
     args = parse_args()
 
     jobs = [
-        ('linter checks', [sys.executable, str(_common.TOOLS_DIR / 'run-linter-checks')]),
+        (
+            'linter checks',
+            [sys.executable, str(_common.TOOLS_DIR / 'run-linter-checks')],
+        ),
         (
             'fast unit tests',
-            [sys.executable, str(_common.TOOLS_DIR / 'run-unit-tests'), '--no-container'],
+            [
+                sys.executable,
+                str(_common.TOOLS_DIR / 'run-unit-tests'),
+                '--no-container',
+            ],
         ),
     ]
     if not args.no_container:
         jobs.append(
-            ('container tests', [sys.executable, str(_common.TOOLS_DIR / 'run-container-tests')])
+            (
+                'container tests',
+                [sys.executable, str(_common.TOOLS_DIR / 'run-container-tests')],
+            )
         )
 
     running = []

--- a/tools/run-linter-checks
+++ b/tools/run-linter-checks
@@ -155,7 +155,13 @@ def main():
     if selected is None or 'bandit' in selected:
         exit_code |= run_analyzer(
             'bandit',
-            ['bandit', '-q', '--severity-level=high', '--confidence-level=high', *python_files],
+            [
+                'bandit',
+                '-q',
+                '--severity-level=high',
+                '--confidence-level=high',
+                *python_files,
+            ],
             stderr_filter=bandit_line_is_noise,
         )
 


### PR DESCRIPTION
The lint configuration grew per repository in April 2026 instead of from a shared template, and firewallfabrik and mcp-server-icinga came from a different project skeleton. That left four dialects behind.

Unified: `line-length` is now stated explicitly as 88 everywhere (the ruff default; checklistfabrik was the outlier at 100), `[tool.ruff.format]` is byte-identical in all six repositories that run ruff, the `select` list is alphabetical, `[tool.bandit.assert_used]` uses one pattern, and strings inside `[tool.*]` are single-quoted. `[build-system]`, `[project]` and `[tool.setuptools]` are left alone: those are per-project and double quotes are the ecosystem norm there.

`target-version`, the `ignore` lists and the extra `PTH`/`TID` rules stay per repository, they follow from the codebase.